### PR TITLE
fix: add missing project csproj files to Dockerfile for dotnet restore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-api
 WORKDIR /src
 COPY Anything.slnx .
 COPY src/Anything.API/Anything.API.csproj src/Anything.API/
+COPY src/Anything.Application/Anything.Application.csproj src/Anything.Application/
+COPY src/Anything.Contracts/Anything.Contracts.csproj src/Anything.Contracts/
+COPY src/Anything.Core/Anything.Core.csproj src/Anything.Core/
+COPY src/Anything.Database/Anything.Database.csproj src/Anything.Database/
+COPY src/Anything.Mediator/Anything.Mediator.csproj src/Anything.Mediator/
 COPY src/Anything.ServiceDefaults/Anything.ServiceDefaults.csproj src/Anything.ServiceDefaults/
 RUN dotnet restore src/Anything.API/Anything.API.csproj
 COPY src/ src/


### PR DESCRIPTION
After the clean architecture refactoring, the API now depends on
Anything.Application, Anything.Contracts, Anything.Core, Anything.Database,
and Anything.Mediator. Without their .csproj files copied before
`dotnet restore`, the build fails with missing project reference errors.

https://claude.ai/code/session_012w85TXn8pxvFKgAa7ShJQU