### PR TITLE
feat: make recipe cards full-width on mobile

### DIFF
--- a/anything-frontend/src/app/recipes/page.tsx
+++ b/anything-frontend/src/app/recipes/page.tsx
@@ -181,7 +181,7 @@ export default function RecipesPage() {
       )}
 
       {filteredRecipes && filteredRecipes.length > 0 && (
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
           {filteredRecipes.map((recipe) => (
             <RecipeCard
               key={recipe.id}


### PR DESCRIPTION
Change grid from `grid-cols-2 sm:grid-cols-3` to `grid-cols-1 sm:grid-cols-2 md:grid-cols-3`
so cards span the full viewport width on mobile, improving readability and tap targets.

https://claude.ai/code/session_01PTN8vArXJUSNSCY3M8r4FZ