### PR TITLE
feat: recommendations contain only name; add browse-all view in admin

### DIFF
--- a/anything-frontend/src/app/admin/recommendations/page.test.tsx
+++ b/anything-frontend/src/app/admin/recommendations/page.test.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 
 // Mock the apiClient module
 const mockPendingGet = jest.fn();
+const mockAllGet = jest.fn();
 const mockApprovePost = jest.fn();
 const mockDeleteFn = jest.fn();
 
@@ -14,6 +15,7 @@ jest.mock("@/lib/apiClient", () => ({
     api: {
       shoppingListRecommendations: {
         pending: { get: (...args: unknown[]) => mockPendingGet(...args) },
+        all: { get: (...args: unknown[]) => mockAllGet(...args) },
         get: jest.fn().mockResolvedValue([]),
         byId: (id: number) => ({
           approve: { post: (...args: unknown[]) => mockApprovePost(id, ...args) },
@@ -56,6 +58,7 @@ describe("AdminRecommendationsPage", () => {
       );
       localStorage.setItem("accessToken", "test-token");
       mockPendingGet.mockResolvedValueOnce([]);
+      mockAllGet.mockResolvedValue([]);
 
       renderWithClient(<AdminRecommendationsPage />);
 
@@ -73,6 +76,7 @@ describe("AdminRecommendationsPage", () => {
       );
       localStorage.setItem("accessToken", "test-token");
       mockPendingGet.mockResolvedValue([]);
+      mockAllGet.mockResolvedValue([]);
 
       renderWithClient(<AdminRecommendationsPage />);
 
@@ -92,6 +96,7 @@ describe("AdminRecommendationsPage", () => {
       );
       localStorage.setItem("accessToken", "test-token");
       mockPendingGet.mockResolvedValue([]);
+      mockAllGet.mockResolvedValue([]);
 
       renderWithClient(<AdminRecommendationsPage />);
 
@@ -115,6 +120,7 @@ describe("AdminRecommendationsPage", () => {
 
     it("should display empty state when no pending recommendations", async () => {
       mockPendingGet.mockResolvedValueOnce([]);
+      mockAllGet.mockResolvedValue([]);
 
       renderWithClient(<AdminRecommendationsPage />);
 
@@ -131,6 +137,7 @@ describe("AdminRecommendationsPage", () => {
         { id: 1, name: null },
         { id: 2, name: "valid item" },
       ]);
+      mockAllGet.mockResolvedValue([]);
 
       renderWithClient(<AdminRecommendationsPage />);
 
@@ -153,6 +160,7 @@ describe("AdminRecommendationsPage", () => {
     it("should approve a recommendation successfully", async () => {
       const user = userEvent.setup();
       mockPendingGet.mockResolvedValue([{ id: 1, name: "Apple" }]);
+      mockAllGet.mockResolvedValue([]);
       mockApprovePost.mockResolvedValueOnce({});
 
       renderWithClient(<AdminRecommendationsPage />);
@@ -172,6 +180,7 @@ describe("AdminRecommendationsPage", () => {
     it("should show error toast when approval fails", async () => {
       const user = userEvent.setup();
       mockPendingGet.mockResolvedValue([{ id: 1, name: "Apple" }]);
+      mockAllGet.mockResolvedValue([]);
       mockApprovePost.mockRejectedValueOnce(new Error("Server error"));
 
       renderWithClient(<AdminRecommendationsPage />);
@@ -202,6 +211,7 @@ describe("AdminRecommendationsPage", () => {
     it("should reject a recommendation successfully", async () => {
       const user = userEvent.setup();
       mockPendingGet.mockResolvedValue([{ id: 2, name: "Banana" }]);
+      mockAllGet.mockResolvedValue([]);
       mockDeleteFn.mockResolvedValueOnce({});
 
       renderWithClient(<AdminRecommendationsPage />);
@@ -221,6 +231,7 @@ describe("AdminRecommendationsPage", () => {
     it("should show error toast when rejection fails", async () => {
       const user = userEvent.setup();
       mockPendingGet.mockResolvedValue([{ id: 2, name: "Banana" }]);
+      mockAllGet.mockResolvedValue([]);
       mockDeleteFn.mockRejectedValueOnce(new Error("Server error"));
 
       renderWithClient(<AdminRecommendationsPage />);
@@ -235,6 +246,69 @@ describe("AdminRecommendationsPage", () => {
         expect(toast.error).toHaveBeenCalledWith(
           "Failed to reject recommendation."
         );
+      });
+    });
+  });
+
+  describe("All Recommendations Tab", () => {
+    beforeEach(() => {
+      localStorage.setItem(
+        "user",
+        JSON.stringify({ email: "admin@test.com", name: "Admin", role: "Admin" })
+      );
+      localStorage.setItem("accessToken", "test-token");
+    });
+
+    it("should show all recommendations when clicking All tab", async () => {
+      const user = userEvent.setup();
+      mockPendingGet.mockResolvedValue([]);
+      mockAllGet.mockResolvedValue([
+        { id: 2, name: "Bread", isApproved: true },
+        { id: 3, name: "Cheese", isApproved: false },
+        { id: 1, name: "Milk", isApproved: true },
+      ]);
+
+      renderWithClient(<AdminRecommendationsPage />);
+
+      await user.click(screen.getByRole("button", { name: /^All/ }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Bread")).toBeInTheDocument();
+        expect(screen.getByText("Cheese")).toBeInTheDocument();
+        expect(screen.getByText("Milk")).toBeInTheDocument();
+      });
+    });
+
+    it("should show approved/pending status badges in all tab", async () => {
+      const user = userEvent.setup();
+      mockPendingGet.mockResolvedValue([]);
+      mockAllGet.mockResolvedValue([
+        { id: 1, name: "Apple", isApproved: true },
+        { id: 2, name: "Banana", isApproved: false },
+      ]);
+
+      renderWithClient(<AdminRecommendationsPage />);
+
+      await user.click(screen.getByRole("button", { name: /^All/ }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Approved")).toBeInTheDocument();
+        // "Pending" appears as both a tab button and a status badge
+        expect(screen.getAllByText("Pending").length).toBeGreaterThanOrEqual(2);
+      });
+    });
+
+    it("should show empty state when no recommendations exist", async () => {
+      const user = userEvent.setup();
+      mockPendingGet.mockResolvedValue([]);
+      mockAllGet.mockResolvedValue([]);
+
+      renderWithClient(<AdminRecommendationsPage />);
+
+      await user.click(screen.getByRole("button", { name: /^All/ }));
+
+      await waitFor(() => {
+        expect(screen.getByText("No recommendations yet.")).toBeInTheDocument();
       });
     });
   });

--- a/anything-frontend/src/app/admin/recommendations/page.tsx
+++ b/anything-frontend/src/app/admin/recommendations/page.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { useCurrentUser } from "@/hooks/useAuth";
 import {
   usePendingRecommendations,
+  useAllRecommendations,
   useApproveRecommendation,
   useDeleteRecommendation,
 } from "@/hooks/useRecommendations";
@@ -11,11 +12,16 @@ import { isAdmin } from "@/lib/roles";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { Check, X } from "lucide-react";
+import { useState } from "react";
+
+type Tab = "pending" | "all";
 
 export default function AdminRecommendationsPage() {
   const { data: user } = useCurrentUser();
   const router = useRouter();
+  const [activeTab, setActiveTab] = useState<Tab>("pending");
   const { data: pendingRecommendations } = usePendingRecommendations();
+  const { data: allRecommendations } = useAllRecommendations();
   const approveRecommendation = useApproveRecommendation();
   const deleteRecommendation = useDeleteRecommendation();
 
@@ -53,6 +59,13 @@ export default function AdminRecommendationsPage() {
     }
   };
 
+  const validPending = (pendingRecommendations ?? []).filter(
+    (rec) => rec.id !== null && rec.name !== null
+  );
+  const validAll = (allRecommendations ?? []).filter(
+    (rec) => rec.id !== null && rec.name !== null
+  );
+
   return (
     <div className="container mx-auto px-4 py-4 max-w-lg">
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 sm:p-6">
@@ -60,46 +73,110 @@ export default function AdminRecommendationsPage() {
           Approved items appear as autocomplete suggestions in shopping lists.
         </p>
 
-        {!pendingRecommendations || pendingRecommendations.length === 0 ? (
-          <p className="text-center text-gray-400 dark:text-gray-500 text-sm py-8">
-            No pending recommendations.
-          </p>
-        ) : (
-          <ul className="space-y-2">
-            {pendingRecommendations.filter((rec) => rec.id !== null && rec.name !== null).map((rec) => (
-              <li
-                key={rec.id}
-                className="flex items-center justify-between gap-3 p-3 border border-gray-200 dark:border-gray-700 rounded-md"
-              >
-                <span className="text-sm text-gray-900 dark:text-white truncate">
-                  {rec.name}
-                </span>
-                <div className="flex gap-2 shrink-0">
-                  <Button
-                    size="sm"
-                    onClick={() => handleApprove(rec.id!)}
-                    disabled={approveRecommendation.isPending}
-                    className="bg-green-600 hover:bg-green-700 text-white px-3"
-                    aria-label="Approve"
+        <div className="flex border-b border-gray-200 dark:border-gray-700 mb-4">
+          <button
+            onClick={() => setActiveTab("pending")}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              activeTab === "pending"
+                ? "border-blue-500 text-blue-600 dark:text-blue-400"
+                : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+            }`}
+          >
+            Pending
+            {validPending.length > 0 && (
+              <span className="ml-2 bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 text-xs font-semibold px-1.5 py-0.5 rounded-full">
+                {validPending.length}
+              </span>
+            )}
+          </button>
+          <button
+            onClick={() => setActiveTab("all")}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              activeTab === "all"
+                ? "border-blue-500 text-blue-600 dark:text-blue-400"
+                : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+            }`}
+          >
+            All
+          </button>
+        </div>
+
+        {activeTab === "pending" && (
+          <>
+            {validPending.length === 0 ? (
+              <p className="text-center text-gray-400 dark:text-gray-500 text-sm py-8">
+                No pending recommendations.
+              </p>
+            ) : (
+              <ul className="space-y-2">
+                {validPending.map((rec) => (
+                  <li
+                    key={rec.id}
+                    className="flex items-center justify-between gap-3 p-3 border border-gray-200 dark:border-gray-700 rounded-md"
                   >
-                    <Check className="h-4 w-4 sm:mr-1" />
-                    <span className="hidden sm:inline">Approve</span>
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="destructive"
-                    onClick={() => handleReject(rec.id!)}
-                    disabled={deleteRecommendation.isPending}
-                    className="px-3"
-                    aria-label="Reject"
+                    <span className="text-sm text-gray-900 dark:text-white truncate">
+                      {rec.name}
+                    </span>
+                    <div className="flex gap-2 shrink-0">
+                      <Button
+                        size="sm"
+                        onClick={() => handleApprove(rec.id!)}
+                        disabled={approveRecommendation.isPending}
+                        className="bg-green-600 hover:bg-green-700 text-white px-3"
+                        aria-label="Approve"
+                      >
+                        <Check className="h-4 w-4 sm:mr-1" />
+                        <span className="hidden sm:inline">Approve</span>
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => handleReject(rec.id!)}
+                        disabled={deleteRecommendation.isPending}
+                        className="px-3"
+                        aria-label="Reject"
+                      >
+                        <X className="h-4 w-4 sm:mr-1" />
+                        <span className="hidden sm:inline">Reject</span>
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+
+        {activeTab === "all" && (
+          <>
+            {validAll.length === 0 ? (
+              <p className="text-center text-gray-400 dark:text-gray-500 text-sm py-8">
+                No recommendations yet.
+              </p>
+            ) : (
+              <ul className="space-y-2">
+                {validAll.map((rec) => (
+                  <li
+                    key={rec.id}
+                    className="flex items-center justify-between gap-3 p-3 border border-gray-200 dark:border-gray-700 rounded-md"
                   >
-                    <X className="h-4 w-4 sm:mr-1" />
-                    <span className="hidden sm:inline">Reject</span>
-                  </Button>
-                </div>
-              </li>
-            ))}
-          </ul>
+                    <span className="text-sm text-gray-900 dark:text-white truncate">
+                      {rec.name}
+                    </span>
+                    <span
+                      className={`text-xs font-medium px-2 py-0.5 rounded-full shrink-0 ${
+                        rec.isApproved
+                          ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+                          : "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"
+                      }`}
+                    >
+                      {rec.isApproved ? "Approved" : "Pending"}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/anything-frontend/src/hooks/useRecommendations.test.tsx
+++ b/anything-frontend/src/hooks/useRecommendations.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactNode } from 'react'
 import {
   useApprovedRecommendations,
+  useAllRecommendations,
   usePendingRecommendations,
   useApproveRecommendation,
   useDeleteRecommendation,
@@ -10,6 +11,7 @@ import {
 
 const mockApprovedGet = jest.fn()
 const mockPendingGet = jest.fn()
+const mockAllGet = jest.fn()
 const mockApprovePost = jest.fn()
 const mockDeleteFn = jest.fn()
 const mockApprove = { post: mockApprovePost }
@@ -20,6 +22,7 @@ jest.mock('@/lib/apiClient', () => ({
     api: {
       shoppingListRecommendations: {
         get: (...args: unknown[]) => mockApprovedGet(...args),
+        all: { get: (...args: unknown[]) => mockAllGet(...args) },
         pending: { get: (...args: unknown[]) => mockPendingGet(...args) },
         byId: (...args: unknown[]) => mockItemById(...args),
       },
@@ -67,6 +70,35 @@ describe('useRecommendations hooks', () => {
       mockApprovedGet.mockRejectedValueOnce(new Error('Network error'))
 
       const { result } = renderHook(() => useApprovedRecommendations(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+  })
+
+  describe('useAllRecommendations', () => {
+    it('fetches all recommendations ordered alphabetically', async () => {
+      const mockAll = [
+        { id: 2, name: 'Bread', isApproved: true },
+        { id: 3, name: 'Cheese', isApproved: false },
+        { id: 1, name: 'Milk', isApproved: true },
+      ]
+      mockAllGet.mockResolvedValueOnce(mockAll)
+
+      const { result } = renderHook(() => useAllRecommendations(), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(result.current.data).toEqual(mockAll)
+      expect(mockAllGet).toHaveBeenCalledTimes(1)
+    })
+
+    it('handles fetch error', async () => {
+      mockAllGet.mockRejectedValueOnce(new Error('Network error'))
+
+      const { result } = renderHook(() => useAllRecommendations(), {
         wrapper: createWrapper(),
       })
 

--- a/anything-frontend/src/hooks/useRecommendations.ts
+++ b/anything-frontend/src/hooks/useRecommendations.ts
@@ -12,6 +12,14 @@ export function useApprovedRecommendations() {
   });
 }
 
+export function useAllRecommendations() {
+  return useQuery({
+    queryKey: ["shoppingListRecommendations", "all"],
+    queryFn: () =>
+      apiClient.api.shoppingListRecommendations.all.get() as Promise<ShoppingListRecommendation[]>,
+  });
+}
+
 export function usePendingRecommendations() {
   return useQuery({
     queryKey: ["shoppingListRecommendations", "pending"],

--- a/anything-frontend/src/lib/api-client/api/shoppingListRecommendations/all/index.ts
+++ b/anything-frontend/src/lib/api-client/api/shoppingListRecommendations/all/index.ts
@@ -1,0 +1,39 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-ignore
+import { createShoppingListRecommendationFromDiscriminatorValue, type ShoppingListRecommendation } from '../../../models/index';
+// @ts-ignore
+import { type BaseRequestBuilder, type RequestConfiguration, type RequestInformation, type RequestsMetadata } from '@microsoft/kiota-abstractions';
+
+/**
+ * Builds and executes requests for operations under /api/shopping-list-recommendations/all
+ */
+export interface AllRequestBuilder extends BaseRequestBuilder<AllRequestBuilder> {
+    /**
+     * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
+     * @returns {Promise<ShoppingListRecommendation[]>}
+     */
+     get(requestConfiguration?: RequestConfiguration<object> | undefined) : Promise<ShoppingListRecommendation[] | undefined>;
+    /**
+     * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
+     * @returns {RequestInformation}
+     */
+     toGetRequestInformation(requestConfiguration?: RequestConfiguration<object> | undefined) : RequestInformation;
+}
+/**
+ * Uri template for the request builder.
+ */
+export const AllRequestBuilderUriTemplate = "{+baseurl}/api/shopping-list-recommendations/all";
+/**
+ * Metadata for all the requests in the request builder.
+ */
+export const AllRequestBuilderRequestsMetadata: RequestsMetadata = {
+    get: {
+        uriTemplate: AllRequestBuilderUriTemplate,
+        responseBodyContentType: "application/json",
+        adapterMethodName: "sendCollection",
+        responseBodyFactory: createShoppingListRecommendationFromDiscriminatorValue,
+    },
+};
+/* tslint:enable */
+/* eslint-enable */

--- a/anything-frontend/src/lib/api-client/api/shoppingListRecommendations/index.ts
+++ b/anything-frontend/src/lib/api-client/api/shoppingListRecommendations/index.ts
@@ -3,6 +3,8 @@
 // @ts-ignore
 import { createShoppingListRecommendationFromDiscriminatorValue, type ShoppingListRecommendation } from '../../models/index';
 // @ts-ignore
+import { AllRequestBuilderRequestsMetadata, type AllRequestBuilder } from './all/index';
+// @ts-ignore
 import { ShoppingListRecommendationsItemRequestBuilderNavigationMetadata, ShoppingListRecommendationsItemRequestBuilderRequestsMetadata, type ShoppingListRecommendationsItemRequestBuilder } from './item/index';
 // @ts-ignore
 import { PendingRequestBuilderRequestsMetadata, type PendingRequestBuilder } from './pending/index';
@@ -13,6 +15,10 @@ import { type BaseRequestBuilder, type KeysToExcludeForNavigationMetadata, type 
  * Builds and executes requests for operations under /api/shopping-list-recommendations
  */
 export interface ShoppingListRecommendationsRequestBuilder extends BaseRequestBuilder<ShoppingListRecommendationsRequestBuilder> {
+    /**
+     * The all property
+     */
+    get all(): AllRequestBuilder;
     /**
      * Gets an item from the ApiSdk.api.shoppingListRecommendations.item collection
      * @param id Unique identifier of the item
@@ -42,6 +48,9 @@ export const ShoppingListRecommendationsRequestBuilderUriTemplate = "{+baseurl}/
  * Metadata for all the navigation properties in the request builder.
  */
 export const ShoppingListRecommendationsRequestBuilderNavigationMetadata: Record<Exclude<keyof ShoppingListRecommendationsRequestBuilder, KeysToExcludeForNavigationMetadata>, NavigationMetadata> = {
+    all: {
+        requestsMetadata: AllRequestBuilderRequestsMetadata,
+    },
     byId: {
         requestsMetadata: ShoppingListRecommendationsItemRequestBuilderRequestsMetadata,
         navigationMetadata: ShoppingListRecommendationsItemRequestBuilderNavigationMetadata,

--- a/src/Anything.API/Endpoints/RecommendationEndpoints.cs
+++ b/src/Anything.API/Endpoints/RecommendationEndpoints.cs
@@ -18,6 +18,13 @@ public static class RecommendationEndpoints
         .WithName("GetApprovedRecommendations")
         .RequireAuthorization();
 
+        group.MapGet("/all", async (IMediator mediator) =>
+        {
+            return await mediator.Send(new GetAllRecommendationsQuery());
+        })
+        .WithName("GetAllRecommendations")
+        .RequireAuthorization(UserRoles.Admin);
+
         group.MapGet("/pending", async (IMediator mediator) =>
         {
             return await mediator.Send(new GetPendingRecommendationsQuery());

--- a/src/Anything.Application/Features/Recommendations/Queries/GetAllRecommendations.cs
+++ b/src/Anything.Application/Features/Recommendations/Queries/GetAllRecommendations.cs
@@ -1,0 +1,20 @@
+using Anything.Core.Entities;
+using Anything.Core.Repositories;
+using Anything.Mediator;
+using Microsoft.EntityFrameworkCore;
+
+namespace Anything.Application.Features.Recommendations.Queries;
+
+public record GetAllRecommendationsQuery : IRequest<List<ShoppingListRecommendation>>;
+
+public class GetAllRecommendationsHandler(IRepository<ShoppingListRecommendation> repository)
+    : IRequestHandler<GetAllRecommendationsQuery, List<ShoppingListRecommendation>>
+{
+    public async Task<List<ShoppingListRecommendation>> Handle(GetAllRecommendationsQuery query, CancellationToken ct = default)
+    {
+        return await repository.Query()
+            .Where(r => r.DeletedOn == null)
+            .OrderBy(r => r.Name)
+            .ToListAsync(ct);
+    }
+}


### PR DESCRIPTION
- Recommendations already only store name (not unit or amount); no model
  changes needed
- Add GetAllRecommendationsQuery handler returning all non-deleted
  recommendations ordered alphabetically
- Add GET /api/shopping-list-recommendations/all endpoint (admin-only)
- Add Kiota client 'all' request builder for the new endpoint
- Add useAllRecommendations hook
- Update admin recommendations page with Pending / All tabs so admins
  can browse all recommendations ordered alphabetically with
  approved/pending status badges
- Update tests for hook and page (21 tests, all passing)

https://claude.ai/code/session_013eJt85QAUCJ8x2epoZMKSj