### PR TITLE
Add recipe import from URL via Schema.org JSON-LD parsing

Introduces POST /api/recipes/parse-url which fetches a recipe page,
extracts Schema.org JSON-LD structured data, and returns a parsed
preview (name, ingredients with amount/unit, ordered steps) for the
user to review before saving. Returns 422 if no Schema.org recipe
markup is found.

https://claude.ai/code/session_01Qoorzp4tsu5hxWbF1u4isD

### DIFF
--- a/src/Anything.API/Endpoints/RecipeEndpoints.cs
+++ b/src/Anything.API/Endpoints/RecipeEndpoints.cs
@@ -35,6 +35,14 @@ public static class RecipeEndpoints
         .WithParameterValidation()
         .RequireAuthorization();
 
+        group.MapPost("/parse-url", async (ParseRecipeFromUrlRequest request, IMediator mediator) =>
+        {
+            return await mediator.Send(new ParseRecipeFromUrlCommand(request.Url));
+        })
+        .WithName("ParseRecipeFromUrl")
+        .WithParameterValidation()
+        .RequireAuthorization();
+
         group.MapPut("/{id}", async (int id, UpdateRecipeRequest request, IMediator mediator) =>
         {
             return await mediator.Send(new UpdateRecipeCommand(id, request.Name, request.Link, request.Notes));

--- a/src/Anything.Application/DependencyInjection.cs
+++ b/src/Anything.Application/DependencyInjection.cs
@@ -32,6 +32,11 @@ public static class DependencyInjection
         services.AddScoped<IPasswordService, PasswordService>();
         services.AddScoped<ITokenService, TokenService>();
         services.AddScoped<IImageStorageService, MinioStorageService>();
+        services.AddHttpClient<IRecipeParserService, RecipeParserService>(client =>
+        {
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("AnythingApp/1.0 (recipe-parser)");
+            client.Timeout = TimeSpan.FromSeconds(30);
+        });
 
         // Background services
         services.AddHostedService<FoodPlanAutoRenewService>();

--- a/src/Anything.Application/Features/Recipes/Commands/ParseRecipeFromUrl.cs
+++ b/src/Anything.Application/Features/Recipes/Commands/ParseRecipeFromUrl.cs
@@ -1,0 +1,31 @@
+using Anything.Application.Services;
+using Anything.Contracts.Recipes;
+using Anything.Mediator;
+using Microsoft.AspNetCore.Http;
+
+namespace Anything.Application.Features.Recipes.Commands;
+
+public record ParseRecipeFromUrlCommand(string Url) : IRequest<IResult>;
+
+public class ParseRecipeFromUrlHandler(IRecipeParserService parserService)
+    : IRequestHandler<ParseRecipeFromUrlCommand, IResult>
+{
+    private const string NoRecipeFound = "No Schema.org recipe data found at the provided URL.";
+
+    public async Task<IResult> Handle(ParseRecipeFromUrlCommand command, CancellationToken ct = default)
+    {
+        ParsedRecipeResponse? result;
+        try
+        {
+            result = await parserService.ParseFromUrl(command.Url, ct);
+        }
+        catch (HttpRequestException)
+        {
+            return Results.BadRequest("Failed to fetch the provided URL.");
+        }
+
+        return result is null
+            ? Results.UnprocessableEntity(NoRecipeFound)
+            : Results.Ok(result);
+    }
+}

--- a/src/Anything.Application/Services/IRecipeParserService.cs
+++ b/src/Anything.Application/Services/IRecipeParserService.cs
@@ -1,0 +1,8 @@
+using Anything.Contracts.Recipes;
+
+namespace Anything.Application.Services;
+
+public interface IRecipeParserService
+{
+    Task<ParsedRecipeResponse?> ParseFromUrl(string url, CancellationToken ct = default);
+}

--- a/src/Anything.Application/Services/RecipeParserService.cs
+++ b/src/Anything.Application/Services/RecipeParserService.cs
@@ -1,0 +1,228 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Anything.Contracts.Recipes;
+
+namespace Anything.Application.Services;
+
+public class RecipeParserService(HttpClient httpClient) : IRecipeParserService
+{
+    private static readonly Regex LeadingNumberRegex = new(
+        @"^((?:\d+\s+)?\d+/\d+|\d+(?:[.,]\d+)?)",
+        RegexOptions.Compiled);
+
+    private static readonly HashSet<string> KnownUnits = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "cup", "cups", "tbsp", "tablespoon", "tablespoons", "tsp", "teaspoon", "teaspoons",
+        "oz", "ounce", "ounces", "lb", "lbs", "pound", "pounds", "g", "gram", "grams",
+        "kg", "kilogram", "kilograms", "ml", "milliliter", "milliliters", "l", "liter", "liters",
+        "clove", "cloves", "can", "cans", "package", "packages", "pkg", "bunch", "bunches",
+        "slice", "slices", "piece", "pieces", "pinch", "handful", "dash",
+        "head", "stalk", "stalks", "sprig", "sprigs"
+    };
+
+    public async Task<ParsedRecipeResponse?> ParseFromUrl(string url, CancellationToken ct = default)
+    {
+        var html = await httpClient.GetStringAsync(url, ct);
+
+        foreach (var json in ExtractJsonLdBlocks(html))
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(json);
+                var recipe = FindRecipeElement(doc.RootElement);
+                if (recipe.HasValue)
+                    return MapToResponse(recipe.Value, url);
+            }
+            catch (JsonException)
+            {
+                // Skip malformed JSON-LD blocks
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> ExtractJsonLdBlocks(string html)
+    {
+        const string marker = "application/ld+json";
+        var pos = 0;
+        while (true)
+        {
+            var start = html.IndexOf(marker, pos, StringComparison.OrdinalIgnoreCase);
+            if (start < 0) yield break;
+
+            var contentStart = html.IndexOf('>', start) + 1;
+            var contentEnd = html.IndexOf("</script>", contentStart, StringComparison.OrdinalIgnoreCase);
+            if (contentStart > 0 && contentEnd > contentStart)
+                yield return html[contentStart..contentEnd].Trim();
+
+            pos = contentEnd > 0 ? contentEnd : start + 1;
+        }
+    }
+
+    private static JsonElement? FindRecipeElement(JsonElement root)
+    {
+        if (root.ValueKind == JsonValueKind.Object)
+        {
+            if (IsRecipeType(root))
+                return root;
+
+            if (root.TryGetProperty("@graph", out var graph) && graph.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in graph.EnumerateArray())
+                {
+                    if (item.ValueKind == JsonValueKind.Object && IsRecipeType(item))
+                        return item;
+                }
+            }
+        }
+        else if (root.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in root.EnumerateArray())
+            {
+                var found = FindRecipeElement(item);
+                if (found.HasValue) return found;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsRecipeType(JsonElement element)
+    {
+        if (!element.TryGetProperty("@type", out var type)) return false;
+        if (type.ValueKind == JsonValueKind.String)
+            return type.GetString()?.Equals("Recipe", StringComparison.OrdinalIgnoreCase) == true;
+        if (type.ValueKind == JsonValueKind.Array)
+            return type.EnumerateArray().Any(t =>
+                t.ValueKind == JsonValueKind.String &&
+                t.GetString()?.Equals("Recipe", StringComparison.OrdinalIgnoreCase) == true);
+        return false;
+    }
+
+    private static ParsedRecipeResponse MapToResponse(JsonElement recipe, string url)
+    {
+        var name = recipe.TryGetProperty("name", out var n) ? n.GetString() ?? "Unknown" : "Unknown";
+
+        var ingredients = new List<ParsedIngredient>();
+        if (recipe.TryGetProperty("recipeIngredient", out var ingArray) && ingArray.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var ing in ingArray.EnumerateArray())
+            {
+                if (ing.ValueKind == JsonValueKind.String)
+                    ingredients.Add(ParseIngredient(ing.GetString() ?? ""));
+            }
+        }
+
+        var steps = new List<ParsedStep>();
+        if (recipe.TryGetProperty("recipeInstructions", out var instructions))
+            steps = ParseInstructions(instructions);
+
+        return new ParsedRecipeResponse(name, url, ingredients, steps);
+    }
+
+    private static List<ParsedStep> ParseInstructions(JsonElement instructions)
+    {
+        var steps = new List<ParsedStep>();
+        var order = 1;
+
+        if (instructions.ValueKind == JsonValueKind.String)
+        {
+            steps.Add(new ParsedStep(order, instructions.GetString() ?? ""));
+            return steps;
+        }
+
+        if (instructions.ValueKind != JsonValueKind.Array)
+            return steps;
+
+        foreach (var item in instructions.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String)
+            {
+                steps.Add(new ParsedStep(order++, item.GetString() ?? ""));
+            }
+            else if (item.ValueKind == JsonValueKind.Object)
+            {
+                var itemType = item.TryGetProperty("@type", out var t) ? t.GetString() : null;
+                if (itemType?.Equals("HowToSection", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    if (item.TryGetProperty("itemListElement", out var subSteps) && subSteps.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var subStep in subSteps.EnumerateArray())
+                        {
+                            var text = GetStepText(subStep);
+                            if (text != null)
+                                steps.Add(new ParsedStep(order++, text));
+                        }
+                    }
+                }
+                else
+                {
+                    var text = GetStepText(item);
+                    if (text != null)
+                        steps.Add(new ParsedStep(order++, text));
+                }
+            }
+        }
+
+        return steps;
+    }
+
+    private static string? GetStepText(JsonElement step)
+    {
+        if (step.TryGetProperty("text", out var text) && text.ValueKind == JsonValueKind.String)
+            return text.GetString();
+        if (step.TryGetProperty("name", out var name) && name.ValueKind == JsonValueKind.String)
+            return name.GetString();
+        return null;
+    }
+
+    private static ParsedIngredient ParseIngredient(string raw)
+    {
+        var text = raw.Trim();
+        var amountMatch = LeadingNumberRegex.Match(text);
+        if (!amountMatch.Success)
+            return new ParsedIngredient(0, null, text);
+
+        var amount = ParseAmount(amountMatch.Value.Trim());
+        var rest = text[amountMatch.Length..].TrimStart();
+        var firstWord = rest.Split(' ', 2)[0];
+
+        if (KnownUnits.Contains(firstWord))
+        {
+            var name = rest.Length > firstWord.Length ? rest[(firstWord.Length + 1)..] : rest;
+            return new ParsedIngredient(amount, firstWord.ToLowerInvariant(), name);
+        }
+
+        return new ParsedIngredient(amount, null, rest);
+    }
+
+    private static decimal ParseAmount(string amountStr)
+    {
+        var parts = amountStr.Trim().Split(' ', 2);
+
+        if (parts.Length == 2)
+        {
+            // Mixed number: "1 1/2"
+            var whole = decimal.TryParse(parts[0], out var w) ? w : 0;
+            var fraction = ParseFraction(parts[1]);
+            return whole + fraction;
+        }
+
+        return ParseFraction(amountStr) is decimal f and > 0
+            ? f
+            : decimal.TryParse(amountStr.Replace(',', '.'),
+                System.Globalization.NumberStyles.Any,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var result) ? result : 0;
+    }
+
+    private static decimal ParseFraction(string s)
+    {
+        var slash = s.IndexOf('/');
+        if (slash < 0) return 0;
+        return decimal.TryParse(s[..slash], out var num) && decimal.TryParse(s[(slash + 1)..], out var den) && den != 0
+            ? num / den
+            : 0;
+    }
+}

--- a/src/Anything.Contracts/Recipes/ParseRecipeFromUrlRequest.cs
+++ b/src/Anything.Contracts/Recipes/ParseRecipeFromUrlRequest.cs
@@ -1,0 +1,8 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Anything.Contracts.Recipes;
+
+public record ParseRecipeFromUrlRequest(
+    [Required(ErrorMessage = "Url is required.")]
+    [Url(ErrorMessage = "Url must be a valid URL.")]
+    string Url);

--- a/src/Anything.Contracts/Recipes/ParsedRecipeResponse.cs
+++ b/src/Anything.Contracts/Recipes/ParsedRecipeResponse.cs
@@ -1,0 +1,7 @@
+namespace Anything.Contracts.Recipes;
+
+public record ParsedIngredient(decimal Amount, string? Unit, string Name);
+
+public record ParsedStep(int Order, string Text);
+
+public record ParsedRecipeResponse(string Name, string? Link, List<ParsedIngredient> Ingredients, List<ParsedStep> Steps);


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/modification
- [ ] CI/CD changes

## Testing
<!-- Describe the tests you ran and/or how to test your changes -->
- [ ] Backend tests pass locally
- [ ] Frontend builds successfully
- [ ] Manual testing performed
- [ ] New tests added (if applicable)

## Checklist
<!-- Mark completed items with an 'x' -->
- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues
<!-- Link to related issues using #issue_number -->
Closes #

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any other context about the PR here -->
