### PR TITLE
fix: correct PWA icon purposes for native-like home screen experience

### DIFF
--- a/anything-frontend/src/app/icon.tsx
+++ b/anything-frontend/src/app/icon.tsx
@@ -18,7 +18,10 @@ export function generateImageMetadata() {
 export default function Icon({ id }: { id: string }) {
   const size = id === "192" ? 192 : 512;
   const fontSize = Math.round(size * 0.45);
-  const radius = Math.round(size * 0.2);
+  // Maskable icons (512) must fill the entire canvas — no border radius —
+  // so the OS can apply its own shape clipping without showing a browser badge.
+  // Regular icons (192, purpose "any") keep rounded corners.
+  const borderRadius = id === "512" ? 0 : Math.round(size * 0.2);
 
   return new ImageResponse(
     (
@@ -30,7 +33,7 @@ export default function Icon({ id }: { id: string }) {
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          borderRadius: radius,
+          borderRadius,
         }}
       >
         <span

--- a/anything-frontend/src/app/manifest.ts
+++ b/anything-frontend/src/app/manifest.ts
@@ -11,18 +11,19 @@ export default function manifest(): MetadataRoute.Manifest {
     theme_color: "#0f172a",
     orientation: "portrait",
     categories: ["productivity", "utilities"],
+    id: "/",
     icons: [
       {
         src: "/icon/192",
         sizes: "192x192",
         type: "image/png",
-        purpose: "maskable",
+        purpose: "any",
       },
       {
         src: "/icon/512",
         sizes: "512x512",
         type: "image/png",
-        purpose: "any",
+        purpose: "maskable",
       },
     ],
   };


### PR DESCRIPTION
The 192x192 icon was incorrectly marked as maskable (it had rounded
corners, which breaks OS shape clipping), and the 512x512 was marked
as "any". Swapped purposes so the 512x512 maskable icon fills the full
canvas (no border radius), allowing Android/Chrome to apply its own
shape without overlaying a browser badge. Also added manifest id field
for stable PWA identity.

https://claude.ai/code/session_017Q7wVBFWta2RaQ1zY21oLn