### PR TITLE
fix: bump service worker cache version to force Android icon refresh

Android Chrome cached the old icon files (/icon/192, /icon/512, /icon/512-maskable)
via the service worker's cache-first strategy under cache name "anything-app-v1".
Bumping the cache name to "anything-app-v2" causes the activate handler to delete
the old cache on next load, forcing a fresh fetch of the updated icons from the network.

https://claude.ai/code/session_01Rp3bqwVvTVYgYufHDEK1pm

### DIFF
--- a/anything-frontend/public/sw.js
+++ b/anything-frontend/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "anything-app-v1";
+const CACHE_NAME = "anything-app-v2";
 const STATIC_ASSETS = ["/", "/login"];
 
 self.addEventListener("install", (event) => {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/modification
- [ ] CI/CD changes

## Testing
<!-- Describe the tests you ran and/or how to test your changes -->
- [ ] Backend tests pass locally
- [ ] Frontend builds successfully
- [ ] Manual testing performed
- [ ] New tests added (if applicable)

## Checklist
<!-- Mark completed items with an 'x' -->
- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues
<!-- Link to related issues using #issue_number -->
Closes #

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any other context about the PR here -->
