### PR TITLE
fix(pwa): fix manifest caching and middleware to allow Chrome WebAPK badge removal

Three root causes of the persistent browser badge:

1. Service worker was caching /manifest.webmanifest — Chrome's ll. Remove it from the
   cache and add a passthrough in — /manifest.webmanifest
   and /sw.js  /icons/
   — unnecessary edge overhead and a potential  manifest explicitly (older Chrome 

https://claude.ai/code/session_012qCcHQn1hVtSNviRH6PLV

### DIFF
--- a/anything-frontend/next.config.ts
+++ b/anything-frontend/next.config.ts
@@ -2,6 +2,22 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  async headers() {
+    return [
+      {
+        // Chrome's WebAPK update checker must always get a fresh manifest to
+        // detect icon/name changes and update the installed PWA badge-free.
+        source: "/manifest.webmanifest",
+        headers: [{ key: "Cache-Control", value: "no-store" }],
+      },
+      {
+        // Service worker must never be served stale — browsers check it on
+        // every load and rely on byte-for-byte comparison to detect updates.
+        source: "/sw.js",
+        headers: [{ key: "Cache-Control", value: "no-store" }],
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {

--- a/anything-frontend/public/sw.js
+++ b/anything-frontend/public/sw.js
@@ -1,8 +1,7 @@
-const CACHE_NAME = "anything-app-v4";
+const CACHE_NAME = "anything-app-v5";
 const STATIC_ASSETS = [
   "/",
   "/login",
-  "/manifest.webmanifest",
   "/icons/icon-192.png",
   "/icons/icon-192-maskable.png",
   "/icons/icon-512.png",
@@ -42,6 +41,12 @@ self.addEventListener("fetch", (event) => {
 
   // Skip API requests — always go to network
   if (url.pathname.startsWith("/api/")) {
+    return;
+  }
+
+  // Never cache the manifest — Chrome's WebAPK update checker must always
+  // fetch a fresh copy to detect icon/name changes and update the installed app.
+  if (url.pathname === "/manifest.webmanifest") {
     return;
   }
 

--- a/anything-frontend/src/app/manifest.ts
+++ b/anything-frontend/src/app/manifest.ts
@@ -6,6 +6,7 @@ export default function manifest(): MetadataRoute.Manifest {
     short_name: "Anything",
     description: "Create anything you want - todos, lists, inventory, and more",
     start_url: "/",
+    scope: "/",
     display: "standalone",
     background_color: "#1c1c26",
     theme_color: "#0f172a",

--- a/anything-frontend/src/middleware.ts
+++ b/anything-frontend/src/middleware.ts
@@ -18,5 +18,7 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+  matcher: [
+    '/((?!api|_next/static|_next/image|favicon.ico|sw.js|manifest.webmanifest|icons/).*)',
+  ],
 };


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/modification
- [ ] CI/CD changes

## Testing
<!-- Describe the tests you ran and/or how to test your changes -->
- [ ] Backend tests pass locally
- [ ] Frontend builds successfully
- [ ] Manual testing performed
- 