### PR TITLE
Add appsettings.Production.json to suppress EF Core SQL query logging

### DIFF
--- a/src/Anything.API/appsettings.Production.json
+++ b/src/Anything.API/appsettings.Production.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
Sets Microsoft.EntityFrameworkCore.Database.Command log level to Warning
in production, preventing verbose SQL statements from bloating production logs
while preserving warnings and errors.

https://claude.ai/code/session_01J9EMELHsdmc2J85gVhLcJ7