### PR TITLE
fix: prevent amount=0 on shopping list items and fix toggle validation error

### DIFF
--- a/anything-frontend/src/app/shopping-lists/[id]/page.tsx
+++ b/anything-frontend/src/app/shopping-lists/[id]/page.tsx
@@ -155,7 +155,7 @@ export default function ShoppingListDetailPage() {
         itemId: item.id!,
         name: item.name!,
         isChecked: !item.isChecked,
-        amount: item.amount ?? null,
+        amount: item.amount != null && item.amount > 0 ? item.amount : null,
         unit: item.unit ?? null,
       });
     } catch {

--- a/src/Anything.Application/Features/FoodPlans/Commands/AddFoodPlanToShoppingList.cs
+++ b/src/Anything.Application/Features/FoodPlans/Commands/AddFoodPlanToShoppingList.cs
@@ -54,7 +54,7 @@ public class AddFoodPlanToShoppingListHandler(
                 {
                     var mult = multiplierLookup.TryGetValue(i.RecipeId, out var m) ? m : 1.0;
                     return i.Amount * (decimal)mult;
-                }),
+                }) is var s && s > 0 ? s : (decimal?)null,
                 Unit: string.IsNullOrWhiteSpace(g.First().Unit) ? null : g.First().Unit?.Trim()
             ))
             .ToList();
@@ -79,7 +79,7 @@ public class AddFoodPlanToShoppingListHandler(
 
             if (existing != null)
             {
-                existing.Amount = (existing.Amount ?? 0) + amount;
+                existing.Amount = amount == null ? existing.Amount : (existing.Amount ?? 0) + amount;
                 existing.ModifiedOn = timeProvider.GetUtcNow().UtcDateTime;
                 shoppingListItemRepository.Update(existing);
             }

--- a/src/Anything.Application/Features/Recipes/Commands/AddRecipeToShoppingList.cs
+++ b/src/Anything.Application/Features/Recipes/Commands/AddRecipeToShoppingList.cs
@@ -39,7 +39,7 @@ public class AddRecipeToShoppingListHandler(
             .GroupBy(i => (Name: i.Name.Trim().ToLower(), Unit: (i.Unit ?? "").Trim().ToLower()))
             .Select(g => (
                 Name: g.First().Name.Trim(),
-                Amount: g.Sum(i => (i.Amount ?? 0) * (decimal)multiplier),
+                Amount: g.Sum(i => (i.Amount ?? 0) * (decimal)multiplier) is var s && s > 0 ? s : (decimal?)null,
                 Unit: string.IsNullOrWhiteSpace(g.First().Unit) ? null : g.First().Unit?.Trim()
             ))
             .ToList();
@@ -64,7 +64,7 @@ public class AddRecipeToShoppingListHandler(
 
             if (existing != null)
             {
-                existing.Amount = (existing.Amount ?? 0) + amount;
+                existing.Amount = amount == null ? existing.Amount : (existing.Amount ?? 0) + amount;
                 existing.ModifiedOn = timeProvider.GetUtcNow().UtcDateTime;
                 shoppingListItemRepository.Update(existing);
             }

--- a/src/Anything.Database/Migrations/20260319000000_NullifyZeroAmountOnShoppingListItems.cs
+++ b/src/Anything.Database/Migrations/20260319000000_NullifyZeroAmountOnShoppingListItems.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Anything.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class NullifyZeroAmountOnShoppingListItems : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "UPDATE \"ShoppingListItems\" SET \"Amount\" = NULL WHERE \"Amount\" = 0;");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Zero amounts were already semantically equivalent to null; no rollback needed.
+        }
+    }
+}


### PR DESCRIPTION
Items added via recipe/food-plan import could end up with amount=0 when
recipe ingredients had null/zero amounts, bypassing the Range(0.001,...) constraint
enforced on direct item creation. Toggling such items would then fail because
the update request sent amount=0 which failed the same Range validation.

- Frontend: normalize amount in handleToggleCheck using the same >0 check as
  parseAmount, so amount=0 is sent as null instead of failing validation
- Backend: normalize computed group sums to null when <= 0 in
  AddRecipeToShoppingList and AddFoodPlanToShoppingList handlers
- Migration: set existing ShoppingListItem rows with amount=0 to null

https://claude.ai/code/session_01BY46bjGdkeTmCzZPDnhmhW