### PR TITLE
fix: improve bill attachment upload error messages and add e2e tests

### DIFF
--- a/anything-frontend/e2e/bills.spec.ts
+++ b/anything-frontend/e2e/bills.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { BillDetailPage } from "./pages/BillDetailPage";
 
 /**
  * Bills full flow:
@@ -55,3 +56,37 @@ test("bill creation form validates required name", async ({ page }) => {
   await expect(submitButton).toBeEnabled();
 });
 
+test("can upload, view, and delete a bill attachment", async ({ page }) => {
+  const billName = `Attachment Bill ${Date.now()}`;
+
+  // 1. Create a bill
+  await page.goto("/bills/new");
+  await page.getByPlaceholder("e.g. Netflix, Electricity").fill(billName);
+  await page.getByRole("button", { name: "Add bill" }).click();
+  await expect(page).toHaveURL("/bills");
+
+  // 2. Navigate to the bill detail page
+  await page.getByText(billName).click();
+  await expect(page).toHaveURL(/\/bills\/\d+/);
+
+  const detailPage = new BillDetailPage(page);
+
+  // 3. Upload a PDF attachment
+  await detailPage.uploadAttachment({
+    name: "invoice.pdf",
+    mimeType: "application/pdf",
+    buffer: Buffer.from("%PDF-1.4 test invoice"),
+  });
+
+  // 4. Verify the attachment appears with the correct name (filename without extension)
+  await expect(detailPage.attachmentLink("invoice")).toBeVisible();
+
+  // 5. Delete the attachment
+  await detailPage.deleteAttachment("invoice");
+  await expect(detailPage.attachmentLink("invoice")).not.toBeVisible();
+
+  // 6. Clean up: delete the bill
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByRole("button", { name: "Delete bill" }).click();
+  await expect(page).toHaveURL("/bills");
+});

--- a/anything-frontend/e2e/pages/BillDetailPage.ts
+++ b/anything-frontend/e2e/pages/BillDetailPage.ts
@@ -1,0 +1,28 @@
+import { Page } from "@playwright/test";
+
+type FileInput = string | { name: string; mimeType: string; buffer: Buffer };
+
+export class BillDetailPage {
+  constructor(private page: Page) {}
+
+  async goto(billId: number) {
+    await this.page.goto(`/bills/${billId}`);
+  }
+
+  async uploadAttachment(file: FileInput) {
+    const fileInput = this.page.locator('input[type="file"]');
+    await fileInput.setInputFiles(file);
+  }
+
+  attachmentLink(name: string) {
+    return this.page.getByRole("link", { name, exact: true });
+  }
+
+  async deleteAttachment(name: string) {
+    const row = this.page
+      .locator("div.px-4.py-3")
+      .filter({ has: this.page.getByRole("link", { name, exact: true }) });
+    this.page.once("dialog", (dialog) => dialog.accept());
+    await row.getByRole("button", { name: "Delete attachment" }).click();
+  }
+}

--- a/anything-frontend/src/app/bills/[id]/page.tsx
+++ b/anything-frontend/src/app/bills/[id]/page.tsx
@@ -190,8 +190,8 @@ export default function BillDetailPage() {
     try {
       await uploadAttachment.mutateAsync({ billId, file });
       toast.success("Attachment uploaded");
-    } catch {
-      toast.error("Failed to upload attachment");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to upload attachment");
     }
     if (fileInputRef.current) fileInputRef.current.value = "";
   };

--- a/anything-frontend/src/hooks/useBills.ts
+++ b/anything-frontend/src/hooks/useBills.ts
@@ -309,7 +309,10 @@ export function useUploadBillAttachment() {
         headers: { Authorization: `Bearer ${getAccessToken()}` },
         body: formData,
       });
-      if (!res.ok) throw new Error("Failed to upload attachment");
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(text || "Failed to upload attachment");
+      }
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ["billAttachments", variables.billId] });


### PR DESCRIPTION
- Read server response body in useUploadBillAttachment to surface specific
  error details (e.g. "Bill not found.") instead of the generic fallback
- Show the error message from the thrown Error in handleFileUpload toast
- Add BillDetailPage POM (e2e/pages/BillDetailPage.ts) with helpers for
  uploading, finding, and deleting attachments
- Add e2e test covering the full attachment lifecycle: upload → verify → delete

https://claude.ai/code/session_01JmmuNghb3tAHy85PKorjfZ