### PR TITLE
Show list name in page title and remove card wrapper from shopping list detail page

### DIFF
--- a/anything-frontend/src/app/shopping-lists/[id]/page.tsx
+++ b/anything-frontend/src/app/shopping-lists/[id]/page.tsx
@@ -267,9 +267,8 @@ export default function ShoppingListDetailPage() {
 
   return (
     <div className="container mx-auto px-4 py-4 max-w-4xl">
-      <PageTitle>Shopping List</PageTitle>
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 sm:p-6">
-        <div className="mb-4">
+      <PageTitle>{list?.name ?? "Shopping List"}</PageTitle>
+      <div className="mb-4">
           {isEditMode && !isCompleted ? (
             editingListName ? (
               <div className="flex items-center gap-2">
@@ -556,7 +555,6 @@ export default function ShoppingListDetailPage() {
             ))}
           </ul>
         )}
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
- Update PageTitle to display the actual shopping list name instead of static "Shopping List"
- Remove the card wrapper (rounded-lg shadow-lg) to use page space more efficiently

https://claude.ai/code/session_01BM6D6HNPkZoWbbowrzLuRV