### PR TITLE
Remove card wrapper from shopping list items for more space

### DIFF
--- a/anything-frontend/src/app/shopping-lists/page.tsx
+++ b/anything-frontend/src/app/shopping-lists/page.tsx
@@ -51,7 +51,7 @@ function DraggableShoppingListItem({ list, onClick }: { list: ShoppingListRespon
   };
 
   return (
-    <div ref={setNodeRef} style={style} className="flex items-center gap-1 px-1">
+    <div ref={setNodeRef} style={style} className="flex items-center gap-1">
       <button
         type="button"
         className="flex items-center justify-center p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 cursor-grab active:cursor-grabbing touch-none"
@@ -63,7 +63,7 @@ function DraggableShoppingListItem({ list, onClick }: { list: ShoppingListRespon
       </button>
       <button
         type="button"
-        className="flex-1 flex items-center justify-between px-2 py-2.5 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors text-left focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="flex-1 flex items-center justify-between px-3 py-2.5 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors text-left focus:outline-none focus:ring-2 focus:ring-blue-500"
         onClick={onClick}
       >
         <span className="text-gray-900 dark:text-white font-medium text-sm">
@@ -222,7 +222,7 @@ export default function ShoppingListsPage() {
             items={lists.map((l) => l.id ?? 0)}
             strategy={verticalListSortingStrategy}
           >
-            <div className="bg-white dark:bg-gray-800 rounded-lg overflow-hidden">
+            <div>
               {lists.map((list) => (
                 <DraggableShoppingListItem
                   key={list.id}
@@ -246,7 +246,7 @@ export default function ShoppingListsPage() {
             </div>
           )}
           {hasCompletedLists && (
-            <div className="bg-white dark:bg-gray-800 rounded-lg overflow-hidden">
+            <div>
               {completedLists.map((list) => (
                 <button
                   key={list.id}


### PR DESCRIPTION
Removed the bg-white/rounded-lg card container that wrapped the list
items on the shopping lists page, letting items use the full available
width. Also removed the px-1 wrapper padding on draggable items and
slightly increased the button's horizontal padding.

https://claude.ai/code/session_01Ba2VSwJDxnP9uKKD6ZGWyW