### PR TITLE
fix(e2e): use heading role locator to avoid strict mode violation in rename test

### DIFF
--- a/anything-frontend/e2e/shopping-lists.spec.ts
+++ b/anything-frontend/e2e/shopping-lists.spec.ts
@@ -80,7 +80,7 @@ test("shopping list can be renamed and deleted", async ({ page }) => {
   await page.getByRole("textbox", { name: "Edit list name" }).fill(newName);
   await page.getByRole("button", { name: "Save list name" }).click();
 
-  await expect(page.getByText(newName)).toBeVisible();
+  await expect(page.getByRole("heading", { name: newName })).toBeVisible();
 
   // Delete the list via the dropdown menu
   await page.getByRole("button", { name: "More options" }).click();


### PR DESCRIPTION
getByText matched both the h1 page title and the h2 list item after rename.
Use getByRole('heading') to uniquely target the page title.

https://claude.ai/code/session_01J8ycNs7T89hBcKYbSzHrWD