### PR TITLE
fix: add missing popover CSS variables to fix transparent context menu background

### DIFF
--- a/anything-frontend/src/app/globals.css
+++ b/anything-frontend/src/app/globals.css
@@ -16,6 +16,8 @@
   --border: #e5e5e5;
   --input: #e5e5e5;
   --ring: #171717;
+  --popover: #ffffff;
+  --popover-foreground: #0a0a0a;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -35,6 +37,8 @@
     --border: #262626;
     --input: #262626;
     --ring: #d4d4d4;
+    --popover: #0a0a0a;
+    --popover-foreground: #fafafa;
   }
 }
 
@@ -54,6 +58,8 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }


### PR DESCRIPTION
The dropdown menu components used bg-popover and text-popover-foreground
but --popover CSS variables were never defined, causing a transparent background.

https://claude.ai/code/session_01R1Uxzf5GhrZFtTc3Gka21g