### PR TITLE
fix(e2e): update tests to match current UI for search and rename flows

### DIFF
--- a/anything-frontend/e2e/recipes.spec.ts
+++ b/anything-frontend/e2e/recipes.spec.ts
@@ -49,21 +49,20 @@ test("recipes can be searched by name", async ({ page }) => {
   // Go to recipes list
   await page.goto("/recipes");
 
-  // Open search
-  await page.getByRole("button", { name: "Search recipes" }).click();
-  await page.getByPlaceholder("Search recipes...").fill(recipeName);
+  // Fill in the always-visible search input
+  await page.getByRole("textbox", { name: "Search recipes" }).fill(recipeName);
 
   // The recipe should be visible
   await expect(page.getByText(recipeName)).toBeVisible();
 
   // Type something that doesn't match
-  await page.getByPlaceholder("Search recipes...").fill("xyznonexistent123");
+  await page.getByRole("textbox", { name: "Search recipes" }).fill("xyznonexistent123");
   await expect(
     page.getByText("No recipes match your search.")
   ).toBeVisible();
 
-  // Close search
-  await page.getByRole("button", { name: "Close search" }).click();
+  // Clear search
+  await page.getByRole("button", { name: "Clear search" }).click();
 });
 
 test("new recipe page shows import-from-url option", async ({ page }) => {

--- a/anything-frontend/e2e/shopping-lists.spec.ts
+++ b/anything-frontend/e2e/shopping-lists.spec.ts
@@ -73,10 +73,9 @@ test("shopping list can be renamed and deleted", async ({ page }) => {
   await page.getByRole("button", { name: "Create list" }).click();
   await expect(page).toHaveURL(/\/shopping-lists\/\d+/);
 
-  // Enter edit mode, then use the dropdown to rename the list
+  // Enter edit mode, then use the "Edit list name" button to rename the list
   await page.getByRole("button", { name: "Edit list" }).click();
-  await page.getByRole("button", { name: "More options" }).click();
-  await page.getByRole("menuitem", { name: "Edit name" }).click();
+  await page.getByRole("button", { name: "Edit list name" }).click();
   const newName = `${listName} Renamed`;
   await page.getByRole("textbox", { name: "Edit list name" }).fill(newName);
   await page.getByRole("button", { name: "Save" }).click();


### PR DESCRIPTION
- Shopping list rename: use dedicated "Edit list name" button instead of
  looking for a non-existent "Edit name" menuitem in the More options dropdown
- Recipes search: the search bar is always visible so remove the "Search
  recipes" button click; also update placeholder and "Close search" →
  "Clear search" to match actual aria-labels

https://claude.ai/code/session_01Hif2BqrDNpezrNTjhaBrR3