### PR TITLE
Show only domain in recipe link display, full URL in edit mode

### DIFF
--- a/anything-frontend/src/app/recipes/[id]/page.tsx
+++ b/anything-frontend/src/app/recipes/[id]/page.tsx
@@ -221,6 +221,15 @@ export default function RecipeDetailPage() {
   const isSafeUrl = (url: string) =>
     url.startsWith("http://") || url.startsWith("https://");
 
+  const getDisplayDomain = (url: string) => {
+    try {
+      const hostname = new URL(url).hostname;
+      return hostname.startsWith("www.") ? hostname.slice(4) : hostname;
+    } catch {
+      return url;
+    }
+  };
+
   const [isEditMode, setIsEditMode] = useState(() => searchParams.get("edit") === "true");
 
   const [editName, setEditName] = useState<string | null>(null);
@@ -830,7 +839,7 @@ export default function RecipeDetailPage() {
                   rel="noopener noreferrer"
                   className="text-blue-600 dark:text-blue-400 hover:underline text-sm block mb-2"
                 >
-                  {recipe.link}
+                  {getDisplayDomain(recipe.link)}
                 </a>
               )}
               {recipe?.notes && (


### PR DESCRIPTION
Adds getDisplayDomain helper that strips www. prefix and shows just
the hostname (e.g. food.com) as the link text while the href still
points to the full original URL. Edit mode continues to show/edit
the full URL.

https://claude.ai/code/session_011C2uo1H6s3zBYcEdtBPjkz