### PR TITLE
Fix shopping list back button not exiting edit mode

### DIFF
--- a/anything-frontend/src/app/shopping-lists/[id]/page.tsx
+++ b/anything-frontend/src/app/shopping-lists/[id]/page.tsx
@@ -26,7 +26,12 @@ export default function ShoppingListDetailPage() {
   const listId = Number(params.id);
 
   const searchParams = useSearchParams();
-  const [isEditMode, setIsEditMode] = useState(() => searchParams.get("edit") === "true");
+  const editParam = searchParams.get("edit") === "true";
+  const [isEditMode, setIsEditMode] = useState(editParam);
+
+  useEffect(() => {
+    setIsEditMode(editParam);
+  }, [editParam]);
   const { setHeaderActions, setLeftAction } = useHeaderActions();
 
   const handleDeleteListRef = useRef<() => void>(() => undefined);


### PR DESCRIPTION
Sync isEditMode state with the URL search param so that browser
back navigation (which removes ?edit=true from the URL) correctly
switches the view back to read mode instead of staying in edit mode.

https://claude.ai/code/session_0184SE8xZ3fQ7RyCuUX55zdg