### PR TITLE
docs: add agent.md files to major directories and link from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,23 @@
 - Do NOT attempt workarounds (manual IL, csc, msbuild invocations, etc.)
 - STOP and inform the user that the tool is missing and another approach is required
 
+## Directory Documentation
+
+Each major directory has an `agent.md` with structure notes and key patterns:
+
+- [`src/Anything.API/agent.md`](src/Anything.API/agent.md)
+- [`src/Anything.Application/agent.md`](src/Anything.Application/agent.md)
+- [`src/Anything.Core/agent.md`](src/Anything.Core/agent.md)
+- [`src/Anything.Database/agent.md`](src/Anything.Database/agent.md)
+- [`src/Anything.Contracts/agent.md`](src/Anything.Contracts/agent.md)
+- [`tests/Anything.API.IntegrationTests/agent.md`](tests/Anything.API.IntegrationTests/agent.md)
+- [`tests/Anything.Application.UnitTests/agent.md`](tests/Anything.Application.UnitTests/agent.md)
+- [`tests/Anything.ArchitectureTests/agent.md`](tests/Anything.ArchitectureTests/agent.md)
+- [`anything-frontend/src/app/agent.md`](anything-frontend/src/app/agent.md)
+- [`anything-frontend/src/components/agent.md`](anything-frontend/src/components/agent.md)
+- [`anything-frontend/src/hooks/agent.md`](anything-frontend/src/hooks/agent.md)
+- [`anything-frontend/src/lib/agent.md`](anything-frontend/src/lib/agent.md)
+
 ## Repository Structure
 
 ```

--- a/anything-frontend/src/app/agent.md
+++ b/anything-frontend/src/app/agent.md
@@ -1,0 +1,22 @@
+# anything-frontend/src/app
+
+Next.js 15 App Router pages. Each subfolder maps 1:1 to a URL segment.
+
+## Structure
+
+- `layout.tsx` / `page.tsx` — root layout (providers, nav shell) and home page
+- `error.tsx`, `global-error.tsx`, `not-found.tsx` — error boundary pages
+- `globals.css` — Tailwind base styles
+- Feature route folders (each typically has `page.tsx` + optionally `page.test.tsx` and page-local components):
+  - `bills/`, `food-plans/`, `households/`, `lists/`, `recipes/`, `shopping-lists/`
+  - `admin/` — invite management, recipe tags, suggestion categories
+  - `login/`, `register/`, `profile/` — auth and user pages
+- Dynamic segments use `[id]/` subfolders with `page.tsx` (detail) and `[id]/edit/page.tsx` (edit form)
+
+## Key Patterns
+
+- Pages are **server components by default** — mark client-only logic in dedicated child components with `"use client"`.
+- Heavy page-specific UI (e.g., `ShoppingListView.tsx`, `ShoppingListEditMode.tsx`) lives alongside the route's `page.tsx`, not in `components/`.
+- Use `AuthGuard` (from `components/`) to wrap protected pages.
+- After any UI change run `npm run test:e2e:visual:update` to regenerate Playwright baseline screenshots, then commit the updated PNGs.
+- Use `page.goto()` for test setup navigation; reserve UI-click navigation only when testing the nav element itself.

--- a/anything-frontend/src/components/agent.md
+++ b/anything-frontend/src/components/agent.md
@@ -1,0 +1,23 @@
+# anything-frontend/src/components
+
+Reusable UI components shared across multiple pages.
+
+## Structure
+
+- Root level — feature-specific shared components:
+  - Dialogs: `AddToFoodPlanDialog`, `CompleteListDialog`, `CreateLocationDialog`, `CreateVendorDialog`, `EditListNameDialog`, `ExportSuggestionsDialog`
+  - Layout/nav: `AppLayout`, `PageTitle`
+  - Feature UI: `CookingModeDrawer`, `ListItemsStatus`, `RecipeImageUpload`
+  - Auth: `AuthGuard`
+  - Error: `ErrorBoundary`
+  - PWA: `ServiceWorkerRegistration`
+- `ui/` — Shadcn UI primitives (`button`, `dialog`, `dropdown-menu`, `sheet`, `combobox-field`, `count-badge`, `sonner`, etc.)
+  - Add new Shadcn components manually by copying from the Shadcn docs into this folder
+
+## Key Patterns
+
+- Components that use hooks or browser APIs must have `"use client"` at the top.
+- Shadcn components in `ui/` are owned by this project — modify them freely (they are not a dependency).
+- Dialogs manage their own open/close state via a companion hook in `src/hooks/` (e.g., `useEditListNameDialog`).
+- Page-specific components (used by only one route) live next to the route's `page.tsx`, not here.
+- `button.test.tsx` is an example of a unit test for a UI primitive — follow that pattern when adding new ui/ components.

--- a/anything-frontend/src/hooks/agent.md
+++ b/anything-frontend/src/hooks/agent.md
@@ -1,0 +1,20 @@
+# anything-frontend/src/hooks
+
+React Query hooks for all API interactions. One file per feature domain.
+
+## Structure
+
+- `use{Feature}.ts` — query + mutation hooks (e.g., `useBills.ts`, `useRecipes.ts`, `useShoppingLists.ts`)
+  - Domains: Auth, Bills, FoodPlans, Households, Inventory (Boxes/Items/StorageUnits), Locations, Recipes, Recommendations, ShoppingLists, Somethings, SuggestionCategories, Vendors
+- Dialog-state hooks: `useAddToFoodPlanDialog.ts`, `useEditListNameDialog.ts`
+- Utility hooks: `useSmartBack.ts` (history-aware back navigation), `useRealtimeSync.ts` (SSE subscription)
+- Most hooks have a paired `.test.tsx` file
+
+## Key Patterns
+
+- All hook files are marked `"use client"` — they cannot be imported in server components.
+- Use `apiClient` from `@/lib/apiClient` for all API calls — never raw `fetch`.
+- Mutations call `queryClient.invalidateQueries(...)` on success to keep the cache fresh.
+- Query keys follow the pattern `[entityName]` or `[entityName, id]` for consistent invalidation.
+- Tests that involve polling/intervals must use `jest.useFakeTimers()` / `jest.useRealTimers()` to prevent CI hangs.
+- Use `renderWithClient` from `@/__tests__/utils/test-utils` for rendering hooks/components in tests.

--- a/anything-frontend/src/lib/agent.md
+++ b/anything-frontend/src/lib/agent.md
@@ -1,0 +1,22 @@
+# anything-frontend/src/lib
+
+Shared utilities and the generated API client.
+
+## Structure
+
+- `apiClient.ts` — configures and exports the Kiota `apiClient` instance; also re-exports `ApiError` (use for catching HTTP errors with `err.responseStatusCode`)
+- `api-client/` — **auto-generated** Kiota client from the backend OpenAPI spec; do not edit manually
+  - Regenerate with `npm run generate:api` (API must be running)
+  - Import types from `@/lib/api-client/models/index`
+- `foodPlanUtils.ts` — date/slot helpers for the food plan calendar
+- `householdUtils.ts` — household membership/role helpers
+- `roles.ts` — role name constants (`HouseholdRoles`, `UserRoles`)
+- `utils.ts` — generic helpers (class merging via `cn()`, etc.)
+
+## Key Patterns
+
+- Always import `apiClient` from `@/lib/apiClient` (the configured instance), not from `api-client/` directly.
+- Use the fluent builder API: `apiClient.api.somethings.get()`, `.post(body)`, `.byId(id).put(body)`, `.byId(id).delete()`.
+- Catch `ApiError` (re-exported from `apiClient.ts`) to handle HTTP error responses — inspect `err.responseStatusCode`.
+- The base URL defaults to `http://localhost:5238` and is overridden by `NEXT_PUBLIC_API_URL` in production.
+- Never cast API response types to `any`; use the generated model types from `api-client/models/index`.

--- a/src/Anything.API/agent.md
+++ b/src/Anything.API/agent.md
@@ -1,0 +1,19 @@
+# Anything.API
+
+Thin HTTP layer. Endpoints extract request data and dispatch to `IMediator.Send()` — no business logic here.
+
+## Structure
+
+- `Endpoints/` — one static class per feature (`BillEndpoints.cs`, `RecipeEndpoints.cs`, etc.) with a `Map*Endpoints()` extension method registered in `Program.cs`
+- `Middleware/HouseholdMiddleware.cs` — resolves the active household from the request and populates `IHouseholdContext`
+- `Realtime/` — `SseConnectionManager` + `SseRealtimeNotifier` for Server-Sent Events push notifications
+- `Program.cs` — app bootstrap: DI registration, middleware pipeline, endpoint mapping
+- `DependencyInjection.cs` — extension methods for wiring up API-layer services
+
+## Key Patterns
+
+- Every endpoint group uses `MapGroup("/api/<entity>")` for consistent route prefixing.
+- Validation is applied via `.WithParameterValidation()` from MinimalApis.Extensions — no manual model-state checks.
+- Auth endpoints use JWT bearer; household-scoped endpoints go through `HouseholdMiddleware`.
+- SSE realtime updates are pushed via `ISseRealtimeNotifier` injected into handlers — no polling.
+- `appsettings.Production.json` overrides connection strings and JWT settings; Aspire injects those in dev via `AppHost`.

--- a/src/Anything.Application/agent.md
+++ b/src/Anything.Application/agent.md
@@ -1,0 +1,27 @@
+# Anything.Application
+
+Business logic layer. Contains all CQRS handlers, domain services, and configuration.
+
+## Structure
+
+- `Features/<Domain>/Commands/` — write-side handlers (`Create*`, `Update*`, `Delete*`)
+- `Features/<Domain>/Queries/` — read-side handlers (`Get*`, `List*`)
+- `Services/` — cross-cutting services:
+  - `TokenService` / `ITokenService` — JWT generation and refresh
+  - `PasswordService` / `IPasswordService` — BCrypt hashing
+  - `RecipeImageService` / `IRecipeImageService` — image upload orchestration
+  - `MinioStorageService` — S3-compatible object storage
+  - `RecipeParserService` / `IRecipeParserService` — scrape/parse recipes from URLs
+  - `HouseholdContext` — scoped carrier for the current household ID
+  - `ShoppingListHelpers`, `BillHelpers` — shared domain logic helpers
+- `Configuration/` — `AdminSettings`, `JwtSettings`, `ImageSettings` (bound from appsettings)
+- `Realtime/` — interfaces for SSE notification contracts
+- `DependencyInjection.cs` — `AddApplication()` extension; uses Scrutor for handler scanning
+
+## Key Patterns
+
+- Each handler is one file: `{Verb}{Noun}Handler.cs` implements `IRequestHandler<TRequest, TResponse>`.
+- Handlers returning domain entities let the endpoint decide the HTTP status code (`Results.Created`); handlers that own HTTP semantics return `IResult` directly.
+- All data access goes through `IRepository<T>` and `IUnitOfWork` — never `DbContext` directly.
+- Soft deletes: queries always filter `WHERE DeletedOn == null`.
+- Timestamps: set `CreatedOn`/`ModifiedOn`/`DeletedOn` to `DateTime.UtcNow` in the handler, not in the DB.

--- a/src/Anything.Contracts/agent.md
+++ b/src/Anything.Contracts/agent.md
@@ -1,0 +1,18 @@
+# Anything.Contracts
+
+API contract layer — request/response DTOs shared between the API and (optionally) clients.
+
+## Structure
+
+One subfolder per feature domain, each containing:
+- `Create*Request.cs`, `Update*Request.cs` — write-side inputs with data annotation validation
+- `*Response.cs` — read-side outputs returned by query handlers
+
+Feature folders: `Auth`, `Bills`, `FoodPlans`, `Households`, `Inventory`, `Locations`, `Recipes`, `Recommendations`, `ShoppingLists`, `Somethings`, `SuggestionCategories`, `Vendors`
+
+## Key Patterns
+
+- Use C# `record` types for all request and response DTOs.
+- Data annotations (`[Required]`, `[MaxLength]`, etc.) live on request records here — validation is triggered by `.WithParameterValidation()` in the API layer.
+- Response records are flat projections — avoid exposing navigation properties or EF entities directly.
+- When adding a new endpoint, add the matching request/response records here first, then wire up the handler and endpoint.

--- a/src/Anything.Core/agent.md
+++ b/src/Anything.Core/agent.md
@@ -1,0 +1,19 @@
+# Anything.Core
+
+Domain layer — zero external dependencies. Everything else depends on this; this depends on nothing.
+
+## Structure
+
+- `Entities/` — 29 domain models (e.g., `Bill`, `Recipe`, `ShoppingList`, `User`, `Household`)
+  - Enums live here too: `ListType`, `PaymentFrequency`, `ServingsType`
+- `Repositories/` — `IRepository<T>`, `IUnitOfWork` (abstractions only)
+- `Services/` — `IHouseholdContext`, `IImageStorageService`, `IPasswordService`, `ITokenService`
+- `Constants/` — `HouseholdRoles`, `UserRoles`
+
+## Key Patterns
+
+- All entities use `CreatedOn`, `ModifiedOn`, `DeletedOn` (nullable) for soft deletes.
+- `IRepository<T>` exposes `Query()` returning `IQueryable<T>` for complex filtering in handlers.
+- `IUnitOfWork` wraps the transaction; call `SaveChangesAsync()` once per handler at the end.
+- No business logic in entities — pure data bags with navigation properties.
+- Interfaces for infrastructure services (`IImageStorageService`, `ITokenService`) are defined here so Application can depend on them without referencing infrastructure assemblies.

--- a/src/Anything.Database/agent.md
+++ b/src/Anything.Database/agent.md
@@ -1,0 +1,20 @@
+# Anything.Database
+
+Infrastructure layer. EF Core implementation of the repository/UoW pattern; owns the DB schema.
+
+## Structure
+
+- `ApplicationDbContext.cs` — single `DbContext`; all `DbSet<T>` registrations here
+- `Configurations/` — one `IEntityTypeConfiguration<T>` class per entity (table names, columns, indexes, FK constraints)
+- `Migrations/` — EF Core auto-generated migration files; never edit manually
+- `Repositories/Repository.cs` — generic `IRepository<T>` implementation backed by `DbContext`
+- `Repositories/UnitOfWork.cs` — wraps `SaveChangesAsync()`
+- `DependencyInjection.cs` — `AddDatabase()` extension; registers DbContext and repositories
+
+## Key Patterns
+
+- Keep all EF-specific config (column types, indexes, cascade rules) in the `Configurations/` classes, not in entity attributes.
+- Add migrations with: `dotnet ef migrations add <Name> --project src/Anything.Database --startup-project src/Anything.API`
+- Apply with: `dotnet ef database update --project src/Anything.Database --startup-project src/Anything.API`
+- Global query filters for soft deletes (`DeletedOn == null`) should be set in entity configurations, not per-query.
+- The `Repository<T>` exposes `Query()` as raw `IQueryable<T>` — callers are responsible for filtering and projection.

--- a/tests/Anything.API.IntegrationTests/agent.md
+++ b/tests/Anything.API.IntegrationTests/agent.md
@@ -1,0 +1,22 @@
+# Anything.API.IntegrationTests
+
+End-to-end integration tests that spin up the real API against a containerised PostgreSQL instance.
+
+## Structure
+
+- `*EndpointTests.cs` — one test class per feature (13 files); covers CRUD happy paths and error cases
+- `Infrastructure/`
+  - `AnythingApiFactory.cs` — `WebApplicationFactory` override; configures the test database
+  - `IntegrationTestBase.cs` — base class providing the typed API client and auth helpers
+  - `IntegrationTestCollection.cs` — xUnit collection fixture tying tests to the shared container
+  - `PostgresContainerFixture.cs` — starts/stops the Testcontainers PostgreSQL instance
+- `ApiClient/` — Kiota-generated typed HTTP client (auto-generated; do not edit manually)
+  - Regenerate with `npm run generate:api` after API changes (requires the API to be running)
+
+## Key Patterns
+
+- All tests inherit `IntegrationTestBase` — use its `Client` property for API calls.
+- The Postgres container is shared across the collection (one container per test run, not per test).
+- Tests register/login a user via `AuthEndpoints` to get a bearer token before calling protected routes.
+- Use unique names per test (e.g., `$"Test {Guid.NewGuid()}"`) to avoid state bleed between tests.
+- Requires Docker to run: `dotnet test tests/Anything.API.IntegrationTests/...`

--- a/tests/Anything.Application.UnitTests/agent.md
+++ b/tests/Anything.Application.UnitTests/agent.md
@@ -1,0 +1,17 @@
+# Anything.Application.UnitTests
+
+Unit tests for CQRS handlers in `Anything.Application`. No database or HTTP — all dependencies are mocked.
+
+## Structure
+
+- `Features/<Domain>/` — one `*HandlerTests.cs` per handler (mirrors Application/Features layout)
+  - Domains covered: Auth, Bills, FoodPlans, Inventory, Locations, Recipes, ShoppingLists, Vendors, Recommendations, Somethings, SuggestionCategories
+- `Services/` — `RecipeParserServiceTests.cs`, `TokenServiceTests.cs`
+- `Helpers/AsyncQueryableExtensions.cs` — test utility that makes `IQueryable<T>` async-compatible for mocking EF Core queries
+
+## Key Patterns
+
+- Mock `IRepository<T>` and `IUnitOfWork` with Moq; return test data from `repository.Query()` via `AsyncQueryableExtensions`.
+- Test one handler per class; name tests `{Method}_{Scenario}_{ExpectedResult}`.
+- For soft-delete tests, verify `DeletedOn` is set rather than checking a database row count.
+- Use `AsyncQueryableExtensions.AsAsyncQueryable()` when setting up `repository.Query()` returns — plain `List<T>.AsQueryable()` breaks async EF operators like `ToListAsync()`.

--- a/tests/Anything.ArchitectureTests/agent.md
+++ b/tests/Anything.ArchitectureTests/agent.md
@@ -1,0 +1,18 @@
+# Anything.ArchitectureTests
+
+Automated enforcement of architectural rules using NetArchTest. Tests fail CI if the rules are broken.
+
+## Structure
+
+- `LayerDependencyTests.cs` — verifies layer dependency direction (Core ← Application ← API; Database not referenced from Application)
+- `CqrsPatternTests.cs` — checks every `IRequestHandler` implementation lives under a `Commands/` or `Queries/` folder
+- `NamingConventionTests.cs` — enforces file/class naming rules (e.g., handlers end in `Handler`, endpoints end in `Endpoints`)
+- `PlacementTests.cs` — validates that entities are only in Core, DTOs only in Contracts, etc.
+- `Assemblies.cs` — central place to resolve assembly references used across all test classes
+- `TestResultExtensions.cs` — helper to produce readable assertion failure messages from NetArchTest results
+
+## Key Patterns
+
+- When adding a new feature, run these tests first — a failing arch test is a signal you've placed code in the wrong layer.
+- `Assemblies.cs` must be updated if a new project is added to the solution.
+- Tests use `NetArchTest.Rules`; failures list the violating types so fixing them is straightforward.


### PR DESCRIPTION
Adds concise per-directory agent.md files covering structure, key files,
and important patterns for each major backend, test, and frontend directory.
CLAUDE.md gains a Directory Documentation section with direct links.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NfCTqZUbGHsKrKWdwymspq