### PR TITLE
fix: correct snapshot path and explicit branch push in update-visual-snapshots workflow

### DIFF
--- a/.github/workflows/update-visual-snapshots.yml
+++ b/.github/workflows/update-visual-snapshots.yml
@@ -48,6 +48,7 @@ jobs:
       run: npm run test:e2e:visual:update
 
     - name: Commit updated snapshots
+      working-directory: ${{ github.workspace }}
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/update-visual-snapshots.yml
+++ b/.github/workflows/update-visual-snapshots.yml
@@ -51,11 +51,10 @@ jobs:
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add e2e/visual.spec.ts-snapshots/
+        git add anything-frontend/e2e/visual.spec.ts-snapshots/
         if git diff --staged --quiet; then
           echo "No snapshot changes to commit"
         else
           git commit -m "chore: update visual snapshots [skip ci]"
-          git push
+          git push origin HEAD:${{ github.ref_name }}
         fi
-      working-directory: ${{ github.workspace }}


### PR DESCRIPTION
The git add was targeting e2e/visual.spec.ts-snapshots/ from the repo root,
but the actual path is anything-frontend/e2e/visual.spec.ts-snapshots/.
This caused every run to stage nothing and skip the commit entirely.
Also made git push explicit to avoid relying on implicit branch tracking.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KaFpQiK3GEdZw3XPFMqmbV