### PR TITLE
fix: replace Pencil icon with LayoutList for edit items mode button

### DIFF
--- a/anything-frontend/src/app/lists/[id]/page.tsx
+++ b/anything-frontend/src/app/lists/[id]/page.tsx
@@ -16,7 +16,7 @@ import { apiClient } from "@/lib/apiClient";
 import { useQuery } from "@tanstack/react-query";
 import { useHeaderActions } from "@/context/PageActionsContext";
 import { PageTitle } from "@/components/PageTitle";
-import { Pencil, Trash2, MoreVertical, SquarePen, ShoppingCart, ListChecks } from "lucide-react";
+import { LayoutList, Trash2, MoreVertical, SquarePen, ShoppingCart, ListChecks } from "lucide-react";
 import { ShoppingListView } from "@/app/shopping-lists/[id]/ShoppingListView";
 import { ShoppingListEditMode } from "@/app/shopping-lists/[id]/ShoppingListEditMode";
 import { GeneralChecklistView } from "./GeneralChecklistView";
@@ -86,7 +86,7 @@ export default function ListDetailPage() {
             onClick={() => { setIsEditMode(true); router.push("?edit=true"); }}
             aria-label="Edit list"
           >
-            <Pencil className="h-5 w-5" />
+            <LayoutList className="h-5 w-5" />
           </Button>
         )}
         <DropdownMenu>


### PR DESCRIPTION
The Pencil icon on the list detail header was ambiguous — it looked like
it would edit the list name, not the list's items. LayoutList clearly
represents list content management and avoids confusion with SquarePen
already used for "Edit list name" in the dropdown.

Closes #517

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X8BefFnuxJHpUFGRfX85au