### PR TITLE
feat: add Rename to action menu always visible in list pages

### DIFF
--- a/anything-frontend/e2e/shopping-lists.spec.ts
+++ b/anything-frontend/e2e/shopping-lists.spec.ts
@@ -73,10 +73,9 @@ test("shopping list can be renamed and deleted", async ({ page }) => {
   await page.getByRole("button", { name: "Create list" }).click();
   await expect(page).toHaveURL(/\/lists\/\d+/);
 
-  // Enter edit mode, then open More options to rename the list
-  await page.getByRole("button", { name: "Edit list" }).click();
+  // Open More options to rename the list (Rename is now always visible, no need to enter edit mode first)
   await page.getByRole("button", { name: "More options" }).click();
-  await page.getByRole("menuitem", { name: "Edit list name" }).click();
+  await page.getByRole("menuitem", { name: "Rename" }).click();
   const newName = `${listName} Renamed`;
   await page.getByRole("textbox", { name: "Edit list name" }).fill(newName);
   await page.getByRole("button", { name: "Save" }).click();

--- a/anything-frontend/src/app/lists/[id]/GeneralChecklistEditMode.test.tsx
+++ b/anything-frontend/src/app/lists/[id]/GeneralChecklistEditMode.test.tsx
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event'
 import { render } from '@/__tests__/utils/test-utils'
 import { GeneralChecklistEditMode } from './GeneralChecklistEditMode'
 import { toast } from 'sonner'
-import { useRef } from 'react'
 
 const mockItemsGet = jest.fn()
 const mockItemsPost = jest.fn()
@@ -41,15 +40,8 @@ jest.mock('sonner', () => ({
   Toaster: () => null,
 }))
 
-function Wrapper({ list }: { list?: { id?: number; name?: string } }) {
-  const ref = useRef<() => void>(() => {})
-  return (
-    <GeneralChecklistEditMode
-      listId={1}
-      list={list}
-      openEditNameDialogRef={ref}
-    />
-  )
+function Wrapper() {
+  return <GeneralChecklistEditMode listId={1} />
 }
 
 describe('GeneralChecklistEditMode', () => {

--- a/anything-frontend/src/app/lists/[id]/GeneralChecklistEditMode.tsx
+++ b/anything-frontend/src/app/lists/[id]/GeneralChecklistEditMode.tsx
@@ -10,11 +10,9 @@ import {
   useReorderShoppingListItems,
   useRemoveShoppingListItem,
 } from "@/hooks/useShoppingLists";
-import { useEditListNameDialog } from "@/hooks/useEditListNameDialog";
 import { toast } from "sonner";
-import { EditListNameDialog } from "@/components/EditListNameDialog";
 import { ListItemsStatus } from "@/components/ListItemsStatus";
-import type { ShoppingList, ShoppingListItem } from "@/lib/api-client/models/index";
+import type { ShoppingListItem } from "@/lib/api-client/models/index";
 import {
   DndContext,
   closestCenter,
@@ -35,8 +33,6 @@ import { CSS } from "@dnd-kit/utilities";
 
 interface Props {
   listId: number;
-  list: ShoppingList | undefined;
-  openEditNameDialogRef: React.MutableRefObject<() => void>;
 }
 
 function DraggableChecklistItem({
@@ -150,7 +146,7 @@ function DraggableChecklistItem({
   );
 }
 
-export function GeneralChecklistEditMode({ listId, list, openEditNameDialogRef }: Props) {
+export function GeneralChecklistEditMode({ listId }: Props) {
   const [newItemName, setNewItemName] = useState("");
   const [editingItem, setEditingItem] = useState<{ id: number; name: string } | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -166,8 +162,6 @@ export function GeneralChecklistEditMode({ listId, list, openEditNameDialogRef }
       coordinateGetter: sortableKeyboardCoordinates,
     })
   );
-
-  const editNameDialog = useEditListNameDialog(listId, list?.name, openEditNameDialogRef);
 
   const handleAddItem = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -242,16 +236,6 @@ export function GeneralChecklistEditMode({ listId, list, openEditNameDialogRef }
 
   return (
     <>
-      <EditListNameDialog
-        open={editNameDialog.open}
-        onOpenChange={editNameDialog.setOpen}
-        value={editNameDialog.value}
-        onChange={editNameDialog.setValue}
-        onSave={editNameDialog.handleSave}
-        isPending={editNameDialog.isPending}
-        inputRef={editNameDialog.inputRef}
-      />
-
       <form onSubmit={handleAddItem} className="mb-4">
         <div className="flex gap-1 items-center">
           <input

--- a/anything-frontend/src/app/lists/[id]/page.test.tsx
+++ b/anything-frontend/src/app/lists/[id]/page.test.tsx
@@ -1,9 +1,12 @@
 import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { render } from '@/__tests__/utils/test-utils'
 import ListDetailPage from './page'
+import { toast } from 'sonner'
 
 const mockGet = jest.fn()
 const mockDelete = jest.fn()
+const mockListPut = jest.fn()
 const mockItemsGet = jest.fn()
 const mockCompletePost = jest.fn()
 const mockItemsReorderPut = jest.fn()
@@ -11,7 +14,7 @@ const mockItemsItemById = jest.fn(() => ({ put: jest.fn(), delete: jest.fn() }))
 const mockById = jest.fn(() => ({
   get: mockGet,
   delete: mockDelete,
-  put: jest.fn(),
+  put: mockListPut,
   items: { get: mockItemsGet, post: jest.fn(), byItemId: mockItemsItemById, reorder: { put: mockItemsReorderPut } },
   complete: { post: mockCompletePost },
 }))
@@ -80,5 +83,34 @@ describe('ListDetailPage', () => {
     mockItemsGet.mockImplementation(() => new Promise(() => {}))
     render(<ListDetailPage />)
     expect(screen.getByText('List')).toBeInTheDocument()
+  })
+
+  it('shows Rename in action menu when not in edit mode', async () => {
+    const user = userEvent.setup()
+    mockGet.mockResolvedValue({ id: 1, name: 'My List', type: 1 })
+    mockItemsGet.mockResolvedValue([])
+    render(<ListDetailPage />)
+    await waitFor(() => expect(screen.getByText('My List')).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: 'More options' }))
+    expect(screen.getByText('Rename')).toBeInTheDocument()
+  })
+
+  it('opens rename dialog and saves new list name', async () => {
+    const user = userEvent.setup()
+    mockGet.mockResolvedValue({ id: 1, name: 'Old Name', type: 1 })
+    mockItemsGet.mockResolvedValue([])
+    mockListPut.mockResolvedValue({ id: 1, name: 'New Name', type: 1 })
+    render(<ListDetailPage />)
+    await waitFor(() => expect(screen.getByText('Old Name')).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: 'More options' }))
+    await user.click(screen.getByText('Rename'))
+    const input = await screen.findByRole('textbox', { name: 'Edit list name' })
+    await user.clear(input)
+    await user.type(input, 'New Name')
+    await user.click(screen.getByRole('button', { name: 'Save list name' }))
+    await waitFor(() => {
+      expect(mockListPut).toHaveBeenCalledWith(expect.objectContaining({ name: 'New Name' }))
+      expect(toast.success).toHaveBeenCalledWith('List name updated')
+    })
   })
 })

--- a/anything-frontend/src/app/lists/[id]/page.tsx
+++ b/anything-frontend/src/app/lists/[id]/page.tsx
@@ -9,6 +9,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useDeleteShoppingList, useConvertShoppingListType } from "@/hooks/useShoppingLists";
+import { useEditListNameDialog } from "@/hooks/useEditListNameDialog";
+import { EditListNameDialog } from "@/components/EditListNameDialog";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import type { ShoppingList } from "@/lib/api-client/models/index";
@@ -48,6 +50,7 @@ export default function ListDetailPage() {
 
   const deleteList = useDeleteShoppingList();
   const convertType = useConvertShoppingListType();
+  const editNameDialog = useEditListNameDialog(listId, list?.name, openEditNameDialogRef);
 
   const isGeneral = list?.type === 0;
 
@@ -96,12 +99,10 @@ export default function ListDetailPage() {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            {isEditMode && (
-              <DropdownMenuItem onSelect={() => openEditNameDialogRef.current()}>
-                <SquarePen className="h-4 w-4" />
-                Edit list name
-              </DropdownMenuItem>
-            )}
+            <DropdownMenuItem onSelect={() => openEditNameDialogRef.current()}>
+              <SquarePen className="h-4 w-4" />
+              Rename
+            </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => handleConvertTypeRef.current()}>
               {isGeneral ? (
                 <>
@@ -135,12 +136,21 @@ export default function ListDetailPage() {
 
   return (
     <div className="container mx-auto px-4 py-4 max-w-4xl">
+      <EditListNameDialog
+        open={editNameDialog.open}
+        onOpenChange={editNameDialog.setOpen}
+        value={editNameDialog.value}
+        onChange={editNameDialog.setValue}
+        onSave={editNameDialog.handleSave}
+        isPending={editNameDialog.isPending}
+        inputRef={editNameDialog.inputRef}
+      />
       <PageTitle>{list?.name ?? "List"}</PageTitle>
       {isEditMode ? (
         isGeneral ? (
-          <GeneralChecklistEditMode listId={listId} list={list} openEditNameDialogRef={openEditNameDialogRef} />
+          <GeneralChecklistEditMode listId={listId} />
         ) : (
-          <ShoppingListEditMode listId={listId} list={list} openEditNameDialogRef={openEditNameDialogRef} />
+          <ShoppingListEditMode listId={listId} />
         )
       ) : (
         isGeneral ? (

--- a/anything-frontend/src/app/shopping-lists/[id]/ShoppingListEditMode.tsx
+++ b/anything-frontend/src/app/shopping-lists/[id]/ShoppingListEditMode.tsx
@@ -9,20 +9,16 @@ import {
   useUpdateShoppingListItem,
   useRemoveShoppingListItem,
 } from "@/hooks/useShoppingLists";
-import { useEditListNameDialog } from "@/hooks/useEditListNameDialog";
 import { useRecommendations } from "@/hooks/useRecommendations";
 import { toast } from "sonner";
-import { EditListNameDialog } from "@/components/EditListNameDialog";
 import { ListItemsStatus } from "@/components/ListItemsStatus";
-import type { ShoppingList, ShoppingListItem } from "@/lib/api-client/models/index";
+import type { ShoppingListItem } from "@/lib/api-client/models/index";
 
 interface Props {
   listId: number;
-  list: ShoppingList | undefined;
-  openEditNameDialogRef: React.MutableRefObject<() => void>;
 }
 
-export function ShoppingListEditMode({ listId, list, openEditNameDialogRef }: Props) {
+export function ShoppingListEditMode({ listId }: Props) {
   const SUGGESTION_CLOSE_DELAY_MS = 150;
 
   const [newItemName, setNewItemName] = useState("");
@@ -44,8 +40,6 @@ export function ShoppingListEditMode({ listId, list, openEditNameDialogRef }: Pr
   const updateItem = useUpdateShoppingListItem(listId);
   const removeItem = useRemoveShoppingListItem(listId);
   const { data: recommendations } = useRecommendations();
-
-  const editNameDialog = useEditListNameDialog(listId, list?.name, openEditNameDialogRef);
 
   const filteredSuggestions =
     recommendations?.filter(
@@ -129,16 +123,6 @@ export function ShoppingListEditMode({ listId, list, openEditNameDialogRef }: Pr
 
   return (
     <>
-      <EditListNameDialog
-        open={editNameDialog.open}
-        onOpenChange={editNameDialog.setOpen}
-        value={editNameDialog.value}
-        onChange={editNameDialog.setValue}
-        onSave={editNameDialog.handleSave}
-        isPending={editNameDialog.isPending}
-        inputRef={editNameDialog.inputRef}
-      />
-
       <form onSubmit={handleAddItem} className="mb-4">
         <div className="flex gap-1 items-center">
           <div className="relative flex-1">

--- a/anything-frontend/src/app/shopping-lists/[id]/page.test.tsx
+++ b/anything-frontend/src/app/shopping-lists/[id]/page.test.tsx
@@ -848,37 +848,35 @@ describe('ShoppingListDetailPage', () => {
     expect(screen.queryByText('Edit name')).not.toBeInTheDocument()
   })
 
-  it('should show Edit list name option in context menu when in edit mode', async () => {
+  it('should show Rename option in context menu', async () => {
     const user = userEvent.setup()
     mockItemsGet.mockResolvedValue([])
 
     render(<ShoppingListDetailPage />)
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Edit list' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'More options' })).toBeInTheDocument()
     })
 
-    await user.click(screen.getByRole('button', { name: 'Edit list' }))
     await user.click(screen.getByRole('button', { name: 'More options' }))
 
     await waitFor(() => {
-      expect(screen.getByRole('menuitem', { name: 'Edit list name' })).toBeInTheDocument()
+      expect(screen.getByRole('menuitem', { name: 'Rename' })).toBeInTheDocument()
     })
   })
 
-  it('should open edit name dialog and save new name', async () => {
+  it('should open rename dialog and save new name', async () => {
     const user = userEvent.setup()
     mockItemsGet.mockResolvedValue([])
 
     render(<ShoppingListDetailPage />)
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Edit list' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'More options' })).toBeInTheDocument()
     })
 
-    await user.click(screen.getByRole('button', { name: 'Edit list' }))
     await user.click(screen.getByRole('button', { name: 'More options' }))
-    await user.click(screen.getByRole('menuitem', { name: 'Edit list name' }))
+    await user.click(screen.getByRole('menuitem', { name: 'Rename' }))
 
     await waitFor(() => {
       expect(screen.getByRole('textbox', { name: 'Edit list name' })).toBeInTheDocument()
@@ -897,7 +895,7 @@ describe('ShoppingListDetailPage', () => {
     expect(toast.success).toHaveBeenCalledWith('List name updated')
   })
 
-  it('should show error toast when edit name fails', async () => {
+  it('should show error toast when rename fails', async () => {
     const user = userEvent.setup()
     mockItemsGet.mockResolvedValue([])
     mockListPut.mockRejectedValueOnce(new Error('Server error'))
@@ -905,12 +903,11 @@ describe('ShoppingListDetailPage', () => {
     render(<ShoppingListDetailPage />)
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Edit list' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'More options' })).toBeInTheDocument()
     })
 
-    await user.click(screen.getByRole('button', { name: 'Edit list' }))
     await user.click(screen.getByRole('button', { name: 'More options' }))
-    await user.click(screen.getByRole('menuitem', { name: 'Edit list name' }))
+    await user.click(screen.getByRole('menuitem', { name: 'Rename' }))
 
     await waitFor(() => {
       expect(screen.getByRole('textbox', { name: 'Edit list name' })).toBeInTheDocument()

--- a/anything-frontend/src/app/shopping-lists/[id]/page.tsx
+++ b/anything-frontend/src/app/shopping-lists/[id]/page.tsx
@@ -9,6 +9,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useDeleteShoppingList } from "@/hooks/useShoppingLists";
+import { useEditListNameDialog } from "@/hooks/useEditListNameDialog";
+import { EditListNameDialog } from "@/components/EditListNameDialog";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import type { ShoppingList } from "@/lib/api-client/models/index";
@@ -44,6 +46,7 @@ export default function ShoppingListDetailPage() {
   });
 
   const deleteList = useDeleteShoppingList();
+  const editNameDialog = useEditListNameDialog(listId, list?.name, openEditNameDialogRef);
 
   // No dependency array: keeps the closure fresh without adding unstable refs to the header effect deps
   useEffect(() => {
@@ -79,12 +82,10 @@ export default function ShoppingListDetailPage() {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            {isEditMode && (
-              <DropdownMenuItem onSelect={() => openEditNameDialogRef.current()}>
-                <SquarePen className="h-4 w-4" />
-                Edit list name
-              </DropdownMenuItem>
-            )}
+            <DropdownMenuItem onSelect={() => openEditNameDialogRef.current()}>
+              <SquarePen className="h-4 w-4" />
+              Rename
+            </DropdownMenuItem>
             <DropdownMenuItem
               className="text-red-600 focus:text-red-600 focus:bg-red-50 dark:focus:bg-red-900/20"
               onSelect={() => handleDeleteListRef.current()}
@@ -104,13 +105,18 @@ export default function ShoppingListDetailPage() {
 
   return (
     <div className="container mx-auto px-4 py-4 max-w-4xl">
+      <EditListNameDialog
+        open={editNameDialog.open}
+        onOpenChange={editNameDialog.setOpen}
+        value={editNameDialog.value}
+        onChange={editNameDialog.setValue}
+        onSave={editNameDialog.handleSave}
+        isPending={editNameDialog.isPending}
+        inputRef={editNameDialog.inputRef}
+      />
       <PageTitle>{list?.name ?? "Shopping List"}</PageTitle>
       {isEditMode ? (
-        <ShoppingListEditMode
-          listId={listId}
-          list={list}
-          openEditNameDialogRef={openEditNameDialogRef}
-        />
+        <ShoppingListEditMode listId={listId} />
       ) : (
         <ShoppingListView listId={listId} />
       )}


### PR DESCRIPTION
Previously the rename option was only shown in the dropdown menu when
the user was in edit mode. Lifts EditListNameDialog and its state hook
to the parent page level so the Rename menu item is always available
regardless of view/edit mode, matching user expectations.

Closes #519

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MfDxWaUaAeoo4uN95JnybV