### PR TITLE
Add tsc typecheck to frontend CI and fix TS errors in tests

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -40,7 +40,10 @@ jobs:
     
     - name: Run ESLint
       run: npm run lint
-    
+
+    - name: Type-check
+      run: npm run typecheck
+
     - name: Build Next.js application
       run: npm run build
       env:

--- a/anything-frontend/package.json
+++ b/anything-frontend/package.json
@@ -9,6 +9,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "jest --forceExit",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage --forceExit",

--- a/anything-frontend/src/app/bills/[id]/page.test.tsx
+++ b/anything-frontend/src/app/bills/[id]/page.test.tsx
@@ -9,11 +9,11 @@ const mockBillByIdDelete = jest.fn()
 const mockPriceHistoryGet = jest.fn()
 const mockPriceHistoryPost = jest.fn()
 const mockPriceHistoryByIdDelete = jest.fn()
-const mockPriceHistoryById = jest.fn(() => ({
+const mockPriceHistoryById: jest.Mock = jest.fn(() => ({
   put: jest.fn(),
   delete: mockPriceHistoryByIdDelete,
 }))
-const mockBillById = jest.fn(() => ({
+const mockBillById: jest.Mock = jest.fn(() => ({
   get: mockBillByIdGet,
   put: jest.fn(),
   delete: mockBillByIdDelete,

--- a/anything-frontend/src/app/food-plans/page.test.tsx
+++ b/anything-frontend/src/app/food-plans/page.test.tsx
@@ -79,7 +79,7 @@ const mockEntriesGet = jest.fn()
 const mockEntriesPost = jest.fn()
 const mockEntriesItemPut = jest.fn()
 const mockEntriesItemDelete = jest.fn()
-const mockEntriesItemById = jest.fn(() => ({ put: mockEntriesItemPut, delete: mockEntriesItemDelete }))
+const mockEntriesItemById: jest.Mock = jest.fn(() => ({ put: mockEntriesItemPut, delete: mockEntriesItemDelete }))
 const mockAddToShoppingListPost = jest.fn()
 const mockShoppingListsGet = jest.fn()
 const mockApiFetch = jest.fn()
@@ -402,7 +402,7 @@ describe('FoodPlanPage', () => {
     await user.click(todayRow)
 
     // Entry appears in the dialog list as well
-    const dialog = screen.getByPlaceholderText('Meal name...').closest('div[class*="rounded-xl"]')!
+    const dialog = screen.getByPlaceholderText('Meal name...').closest<HTMLElement>('div[class*="rounded-xl"]')!
     expect(within(dialog).getByText('Pancakes')).toBeInTheDocument()
     expect(within(dialog).getByRole('button', { name: 'Remove entry' })).toBeInTheDocument()
   })

--- a/anything-frontend/src/app/households/[id]/page.test.tsx
+++ b/anything-frontend/src/app/households/[id]/page.test.tsx
@@ -46,7 +46,7 @@ jest.mock('@/context/HouseholdContext', () => ({
 }))
 
 const mockPush = jest.fn()
-const mockUseParams = jest.fn(() => ({ id: '1' }))
+const mockUseParams: jest.Mock = jest.fn(() => ({ id: '1' }))
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush, back: jest.fn() }),
   useParams: (...args: unknown[]) => mockUseParams(...args),

--- a/anything-frontend/src/app/households/page.test.tsx
+++ b/anything-frontend/src/app/households/page.test.tsx
@@ -13,10 +13,10 @@ const defaultHouseholds = [
   { id: 2, name: 'Work Team', role: 'Member', createdOn: '2024-02-01T00:00:00Z' },
 ]
 
-const mockUseHouseholdContext = jest.fn(() => ({
+const mockUseHouseholdContext: jest.Mock = jest.fn(() => ({
   households: defaultHouseholds,
   isLoading: false,
-  selectedHouseholdId: 1,
+  selectedHouseholdId: 1 as number | null,
   setSelectedHouseholdId: mockSetSelectedHouseholdId,
 }))
 

--- a/anything-frontend/src/app/lists/[id]/GeneralChecklistEditMode.test.tsx
+++ b/anything-frontend/src/app/lists/[id]/GeneralChecklistEditMode.test.tsx
@@ -9,9 +9,9 @@ const mockItemsPost = jest.fn()
 const mockItemsItemDelete = jest.fn()
 const mockItemsItemPut = jest.fn()
 const mockItemsReorderPut = jest.fn()
-const mockItemsItemById = jest.fn(() => ({ delete: mockItemsItemDelete, put: mockItemsItemPut }))
+const mockItemsItemById: jest.Mock = jest.fn(() => ({ delete: mockItemsItemDelete, put: mockItemsItemPut }))
 const mockListPut = jest.fn()
-const mockById = jest.fn(() => ({
+const mockById: jest.Mock = jest.fn(() => ({
   get: jest.fn(),
   put: mockListPut,
   delete: jest.fn(),

--- a/anything-frontend/src/app/lists/[id]/GeneralChecklistView.test.tsx
+++ b/anything-frontend/src/app/lists/[id]/GeneralChecklistView.test.tsx
@@ -9,8 +9,8 @@ const mockItemsItemPut = jest.fn()
 const mockItemsReorderPut = jest.fn()
 const mockCompletePost = jest.fn()
 const mockDelete = jest.fn()
-const mockItemsItemById = jest.fn(() => ({ put: mockItemsItemPut, delete: jest.fn() }))
-const mockById = jest.fn(() => ({
+const mockItemsItemById: jest.Mock = jest.fn(() => ({ put: mockItemsItemPut, delete: jest.fn() }))
+const mockById: jest.Mock = jest.fn(() => ({
   get: jest.fn(),
   put: jest.fn(),
   delete: mockDelete,

--- a/anything-frontend/src/app/lists/[id]/page.test.tsx
+++ b/anything-frontend/src/app/lists/[id]/page.test.tsx
@@ -10,8 +10,8 @@ const mockListPut = jest.fn()
 const mockItemsGet = jest.fn()
 const mockCompletePost = jest.fn()
 const mockItemsReorderPut = jest.fn()
-const mockItemsItemById = jest.fn(() => ({ put: jest.fn(), delete: jest.fn() }))
-const mockById = jest.fn(() => ({
+const mockItemsItemById: jest.Mock = jest.fn(() => ({ put: jest.fn(), delete: jest.fn() }))
+const mockById: jest.Mock = jest.fn(() => ({
   get: mockGet,
   delete: mockDelete,
   put: mockListPut,

--- a/anything-frontend/src/app/recipes/[id]/edit/page.test.tsx
+++ b/anything-frontend/src/app/recipes/[id]/edit/page.test.tsx
@@ -19,10 +19,10 @@ const mockImagesGet = jest.fn()
 const mockImagesUploadPost = jest.fn().mockResolvedValue(undefined)
 const mockImageByIdDelete = jest.fn()
 const mockRecipeDelete = jest.fn()
-const mockIngredientById = jest.fn(() => ({ put: mockIngredientByIdPut, delete: mockIngredientByIdDelete }))
-const mockStepById = jest.fn(() => ({ put: mockStepByIdPut, delete: mockStepByIdDelete }))
-const mockImageById = jest.fn(() => ({ delete: mockImageByIdDelete }))
-const mockById = jest.fn(() => ({
+const mockIngredientById: jest.Mock = jest.fn(() => ({ put: mockIngredientByIdPut, delete: mockIngredientByIdDelete }))
+const mockStepById: jest.Mock = jest.fn(() => ({ put: mockStepByIdPut, delete: mockStepByIdDelete }))
+const mockImageById: jest.Mock = jest.fn(() => ({ delete: mockImageByIdDelete }))
+const mockById: jest.Mock = jest.fn(() => ({
   get: mockRecipeGet,
   put: mockRecipePut,
   delete: mockRecipeDelete,

--- a/anything-frontend/src/app/recipes/[id]/page.test.tsx
+++ b/anything-frontend/src/app/recipes/[id]/page.test.tsx
@@ -12,7 +12,7 @@ const mockImagesGet = jest.fn()
 const mockAddToShoppingListPost = jest.fn()
 const mockRecipeDelete = jest.fn()
 
-const mockById = jest.fn(() => ({
+const mockById: jest.Mock = jest.fn(() => ({
   get: mockRecipeGet,
   delete: mockRecipeDelete,
   ingredients: { get: mockIngredientsGet },

--- a/anything-frontend/src/app/shopping-lists/[id]/page.test.tsx
+++ b/anything-frontend/src/app/shopping-lists/[id]/page.test.tsx
@@ -12,8 +12,8 @@ const mockItemsPost = jest.fn()
 const mockItemsItemPut = jest.fn()
 const mockItemsItemDelete = jest.fn()
 const mockCompletePost = jest.fn()
-const mockItemsItemById = jest.fn(() => ({ put: mockItemsItemPut, delete: mockItemsItemDelete }))
-const mockById = jest.fn(() => ({
+const mockItemsItemById: jest.Mock = jest.fn(() => ({ put: mockItemsItemPut, delete: mockItemsItemDelete }))
+const mockById: jest.Mock = jest.fn(() => ({
   get: mockListGet,
   put: mockListPut,
   delete: jest.fn(),
@@ -771,7 +771,7 @@ describe('ShoppingListDetailPage', () => {
     mockItemsGet.mockResolvedValue([])
     jest.mocked(
       (await import('@/lib/apiClient')).apiClient.api.shoppingListRecommendations.get
-    ).mockResolvedValue([{ id: 1, name: 'Milk', preferredUnit: 'l', isApproved: true }])
+    ).mockResolvedValue([{ id: 1, name: 'Milk', preferredUnit: 'l' }])
 
     render(<ShoppingListDetailPage />)
 
@@ -934,6 +934,7 @@ describe('ShoppingListDetailPage', () => {
     const mockListDelete = jest.fn().mockResolvedValueOnce(undefined)
     mockById.mockReturnValue({
       get: mockListGet,
+      put: mockListPut,
       delete: mockListDelete,
       items: {
         get: mockItemsGet,
@@ -971,6 +972,7 @@ describe('ShoppingListDetailPage', () => {
     const mockListDelete = jest.fn().mockRejectedValueOnce(new Error('Server error'))
     mockById.mockReturnValue({
       get: mockListGet,
+      put: mockListPut,
       delete: mockListDelete,
       items: {
         get: mockItemsGet,

--- a/anything-frontend/src/hooks/useBackInterceptor.test.ts
+++ b/anything-frontend/src/hooks/useBackInterceptor.test.ts
@@ -2,14 +2,15 @@ import { renderHook, act } from "@testing-library/react";
 import { useBackInterceptor } from "./useBackInterceptor";
 
 jest.mock("sonner", () => {
-  const toastFn = jest.fn().mockReturnValue("mock-toast-id");
-  toastFn.dismiss = jest.fn();
+  const toastFn = Object.assign(jest.fn().mockReturnValue("mock-toast-id"), {
+    dismiss: jest.fn(),
+  });
   return { toast: toastFn };
 });
 
 import { toast } from "sonner";
 
-const mockToast = toast as jest.Mock;
+const mockToast = toast as unknown as jest.Mock;
 const mockDismiss = (toast as unknown as { dismiss: jest.Mock }).dismiss;
 
 describe("useBackInterceptor", () => {

--- a/anything-frontend/src/hooks/useBills.test.tsx
+++ b/anything-frontend/src/hooks/useBills.test.tsx
@@ -29,7 +29,7 @@ const mockPriceHistoryPost = jest.fn()
 const mockPriceHistoryByIdPut = jest.fn()
 const mockPriceHistoryByIdDelete = jest.fn()
 
-const mockPriceHistoryById = jest.fn(() => ({
+const mockPriceHistoryById: jest.Mock = jest.fn(() => ({
   put: mockPriceHistoryByIdPut,
   delete: mockPriceHistoryByIdDelete,
 }))
@@ -45,7 +45,7 @@ const mockAttachmentsPost = jest.fn()
 const mockAttachmentItemPut = jest.fn()
 const mockAttachmentItemDelete = jest.fn()
 const mockAttachmentDownloadGet = jest.fn()
-const mockAttachmentItemById = jest.fn(() => ({
+const mockAttachmentItemById: jest.Mock = jest.fn(() => ({
   put: mockAttachmentItemPut,
   delete: mockAttachmentItemDelete,
   download: { get: mockAttachmentDownloadGet },
@@ -57,7 +57,7 @@ const mockAttachments = {
   byAttachmentId: (...args: unknown[]) => mockAttachmentItemById(...args),
 }
 
-const mockBillById = jest.fn(() => ({
+const mockBillById: jest.Mock = jest.fn(() => ({
   get: mockBillByIdGet,
   put: mockBillByIdPut,
   delete: mockBillByIdDelete,

--- a/anything-frontend/src/hooks/useFoodPlans.test.tsx
+++ b/anything-frontend/src/hooks/useFoodPlans.test.tsx
@@ -21,7 +21,7 @@ const mockEntriesGet = jest.fn()
 const mockEntriesPost = jest.fn()
 const mockEntriesItemPut = jest.fn()
 const mockEntriesItemDelete = jest.fn()
-const mockEntriesItemById = jest.fn(() => ({ put: mockEntriesItemPut, delete: mockEntriesItemDelete }))
+const mockEntriesItemById: jest.Mock = jest.fn(() => ({ put: mockEntriesItemPut, delete: mockEntriesItemDelete }))
 const mockAddToShoppingListPost = jest.fn()
 const mockApiFetch = jest.fn()
 

--- a/anything-frontend/src/hooks/useInventoryBoxes.test.tsx
+++ b/anything-frontend/src/hooks/useInventoryBoxes.test.tsx
@@ -13,7 +13,7 @@ const mockGet = jest.fn()
 const mockPost = jest.fn()
 const mockByIdPut = jest.fn()
 const mockByIdDelete = jest.fn()
-const mockById = jest.fn(() => ({ put: mockByIdPut, delete: mockByIdDelete }))
+const mockById: jest.Mock = jest.fn(() => ({ put: mockByIdPut, delete: mockByIdDelete }))
 
 jest.mock('@/lib/apiClient', () => ({
   apiClient: {

--- a/anything-frontend/src/hooks/useInventoryItems.test.tsx
+++ b/anything-frontend/src/hooks/useInventoryItems.test.tsx
@@ -13,7 +13,7 @@ const mockGet = jest.fn()
 const mockPost = jest.fn()
 const mockByIdPut = jest.fn()
 const mockByIdDelete = jest.fn()
-const mockById = jest.fn(() => ({ put: mockByIdPut, delete: mockByIdDelete }))
+const mockById: jest.Mock = jest.fn(() => ({ put: mockByIdPut, delete: mockByIdDelete }))
 
 jest.mock('@/lib/apiClient', () => ({
   apiClient: {

--- a/anything-frontend/src/hooks/useInventoryStorageUnits.test.tsx
+++ b/anything-frontend/src/hooks/useInventoryStorageUnits.test.tsx
@@ -13,7 +13,7 @@ const mockGet = jest.fn()
 const mockPost = jest.fn()
 const mockByIdPut = jest.fn()
 const mockByIdDelete = jest.fn()
-const mockById = jest.fn(() => ({ put: mockByIdPut, delete: mockByIdDelete }))
+const mockById: jest.Mock = jest.fn(() => ({ put: mockByIdPut, delete: mockByIdDelete }))
 
 jest.mock('@/lib/apiClient', () => ({
   apiClient: {

--- a/anything-frontend/src/hooks/useLocations.test.tsx
+++ b/anything-frontend/src/hooks/useLocations.test.tsx
@@ -12,7 +12,7 @@ const mockGet = jest.fn()
 const mockPost = jest.fn()
 const mockByIdPut = jest.fn()
 const mockByIdDelete = jest.fn()
-const mockById = jest.fn(() => ({ put: mockByIdPut, delete: mockByIdDelete }))
+const mockById: jest.Mock = jest.fn(() => ({ put: mockByIdPut, delete: mockByIdDelete }))
 
 jest.mock('@/lib/apiClient', () => ({
   apiClient: {

--- a/anything-frontend/src/hooks/useRecipes.test.tsx
+++ b/anything-frontend/src/hooks/useRecipes.test.tsx
@@ -33,19 +33,19 @@ const mockIngredientsGet = jest.fn()
 const mockIngredientsPost = jest.fn()
 const mockIngredientsItemPut = jest.fn()
 const mockIngredientsItemDelete = jest.fn()
-const mockIngredientsItemById = jest.fn(() => ({ put: mockIngredientsItemPut, delete: mockIngredientsItemDelete }))
+const mockIngredientsItemById: jest.Mock = jest.fn(() => ({ put: mockIngredientsItemPut, delete: mockIngredientsItemDelete }))
 const mockIngredientsReorderPut = jest.fn()
 const mockIngredientsReorder = { put: mockIngredientsReorderPut }
 const mockIngredients = { get: mockIngredientsGet, post: mockIngredientsPost, byIngredientId: mockIngredientsItemById, reorder: mockIngredientsReorder }
 const mockStepsGet = jest.fn()
 const mockStepsPost = jest.fn()
-const mockStepsItemById = jest.fn(() => ({ put: jest.fn(), delete: jest.fn() }))
+const mockStepsItemById: jest.Mock = jest.fn(() => ({ put: jest.fn(), delete: jest.fn() }))
 const mockStepsReorderPut = jest.fn()
 const mockStepsReorder = { put: mockStepsReorderPut }
 const mockSteps = { get: mockStepsGet, post: mockStepsPost, byStepId: mockStepsItemById, reorder: mockStepsReorder }
 const mockImagesGet = jest.fn()
 const mockImagesPost = jest.fn()
-const mockImagesItemById = jest.fn(() => ({ delete: jest.fn() }))
+const mockImagesItemById: jest.Mock = jest.fn(() => ({ delete: jest.fn() }))
 const mockImagesUploadPost = jest.fn()
 const mockImagesUpload = { post: mockImagesUploadPost }
 const mockImages = { get: mockImagesGet, post: mockImagesPost, byImageId: mockImagesItemById, upload: mockImagesUpload }
@@ -54,9 +54,9 @@ const mockAddToShoppingList = { post: mockAddToShoppingListPost }
 const mockTagsGet = jest.fn()
 const mockTagsPost = jest.fn()
 const mockTagsItemDelete = jest.fn()
-const mockTagsItemById = jest.fn(() => ({ delete: mockTagsItemDelete }))
+const mockTagsItemById: jest.Mock = jest.fn(() => ({ delete: mockTagsItemDelete }))
 const mockTags = { get: mockTagsGet, post: mockTagsPost, byTagId: mockTagsItemById }
-const mockById = jest.fn(() => ({
+const mockById: jest.Mock = jest.fn(() => ({
   get: mockGet,
   put: mockPut,
   delete: mockDelete,

--- a/anything-frontend/src/hooks/useRecommendations.test.tsx
+++ b/anything-frontend/src/hooks/useRecommendations.test.tsx
@@ -12,7 +12,7 @@ const mockGet = jest.fn()
 const mockAllGet = jest.fn()
 const mockDeleteFn = jest.fn()
 const mockPutFn = jest.fn()
-const mockItemById = jest.fn(() => ({ delete: mockDeleteFn, put: mockPutFn }))
+const mockItemById: jest.Mock = jest.fn(() => ({ delete: mockDeleteFn, put: mockPutFn }))
 
 jest.mock('@/lib/apiClient', () => ({
   apiClient: {

--- a/anything-frontend/src/hooks/useShoppingLists.test.tsx
+++ b/anything-frontend/src/hooks/useShoppingLists.test.tsx
@@ -24,11 +24,11 @@ const mockItemsPost = jest.fn()
 const mockItemsItemPut = jest.fn()
 const mockItemsItemDelete = jest.fn()
 const mockItemsReorderPut = jest.fn()
-const mockItemsItemById = jest.fn(() => ({ put: mockItemsItemPut, delete: mockItemsItemDelete }))
+const mockItemsItemById: jest.Mock = jest.fn(() => ({ put: mockItemsItemPut, delete: mockItemsItemDelete }))
 const mockCompletePost = jest.fn()
 const mockItems = { get: mockItemsGet, post: mockItemsPost, byItemId: mockItemsItemById, reorder: { put: mockItemsReorderPut } }
 const mockComplete = { post: mockCompletePost }
-const mockById = jest.fn(() => ({ delete: mockDelete, get: mockGet, put: mockPut, items: mockItems, complete: mockComplete }))
+const mockById: jest.Mock = jest.fn(() => ({ delete: mockDelete, get: mockGet, put: mockPut, items: mockItems, complete: mockComplete }))
 
 jest.mock('@/lib/apiClient', () => ({
   apiClient: {

--- a/anything-frontend/src/hooks/useSomethings.test.tsx
+++ b/anything-frontend/src/hooks/useSomethings.test.tsx
@@ -13,7 +13,7 @@ const mockGet = jest.fn()
 const mockPost = jest.fn()
 const mockByIdPut = jest.fn()
 const mockByIdDelete = jest.fn()
-const mockById = jest.fn(() => ({ put: mockByIdPut, delete: mockByIdDelete }))
+const mockById: jest.Mock = jest.fn(() => ({ put: mockByIdPut, delete: mockByIdDelete }))
 
 jest.mock('@/lib/apiClient', () => ({
   apiClient: {

--- a/anything-frontend/src/hooks/useSuggestionCategories.test.tsx
+++ b/anything-frontend/src/hooks/useSuggestionCategories.test.tsx
@@ -14,7 +14,7 @@ const mockPostFn = jest.fn()
 const mockPutFn = jest.fn()
 const mockDeleteFn = jest.fn()
 const mockReorderPutFn = jest.fn()
-const mockItemById = jest.fn(() => ({ put: mockPutFn, delete: mockDeleteFn }))
+const mockItemById: jest.Mock = jest.fn(() => ({ put: mockPutFn, delete: mockDeleteFn }))
 
 jest.mock('@/lib/apiClient', () => ({
   apiClient: {

--- a/anything-frontend/src/hooks/useVendors.test.tsx
+++ b/anything-frontend/src/hooks/useVendors.test.tsx
@@ -12,7 +12,7 @@ const mockGet = jest.fn()
 const mockPost = jest.fn()
 const mockByIdPut = jest.fn()
 const mockByIdDelete = jest.fn()
-const mockById = jest.fn(() => ({ put: mockByIdPut, delete: mockByIdDelete }))
+const mockById: jest.Mock = jest.fn(() => ({ put: mockByIdPut, delete: mockByIdDelete }))
 
 jest.mock('@/lib/apiClient', () => ({
   apiClient: {


### PR DESCRIPTION
Frontend CI did not type-check test files: `next build` skips them and
`jest` transpiles without type-checking, so ~33 TypeScript errors in
`*.test.tsx`/`*.test.ts` accumulated invisibly.

- Add a `typecheck` script (`tsc --noEmit`) to package.json and run it as
  a step in the lint-and-build job of frontend-ci.yml.
- Fix all existing test type errors:
  - Annotate spread-called jest mock factories as `jest.Mock` so
    `(...args) => factory(...args)` wrappers type-check (TS2556).
  - food-plans: make `closest` generic (`closest<HTMLElement>`).
  - households: widen `selectedHouseholdId` default to `number | null`.
  - shopping-lists: drop stale `isApproved`, add missing `put` to mocks.
  - useBackInterceptor: build the toast mock with `Object.assign` and
    cast through `unknown`.

Resolves #577

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XafcADxKZQbLtDnQy6qqi9