### PR TITLE
Add concurrency guards to prevent redundant workflow runs

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -16,6 +16,10 @@ on:
       - 'Anything.slnx'
       - '.github/workflows/backend-ci.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     name: Build and Test (.NET)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
 
+# Deploys must not be cancelled mid-flight (could leave CapRover in a partial
+# state), so queue overlapping runs instead of aborting the in-progress one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -12,6 +12,10 @@ on:
       - 'anything-frontend/**'
       - '.github/workflows/frontend-ci.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-and-build:
     name: Lint and Build (Next.js)

--- a/.github/workflows/update-api-client.yml
+++ b/.github/workflows/update-api-client.yml
@@ -15,6 +15,10 @@ on:
       - 'src/Anything.Core/**'
       - '.github/workflows/update-api-client.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-api-client:
     name: Regenerate API Client

--- a/.github/workflows/update-ef-migrations.yml
+++ b/.github/workflows/update-ef-migrations.yml
@@ -14,6 +14,10 @@ on:
       - 'src/Anything.Database/**'
       - '.github/workflows/update-ef-migrations.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-migrations:
     name: Regenerate EF Migrations

--- a/.github/workflows/update-visual-snapshots.yml
+++ b/.github/workflows/update-visual-snapshots.yml
@@ -14,6 +14,10 @@ on:
       - 'anything-frontend/tailwind.config.*'
       - '.github/workflows/update-visual-snapshots.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-snapshots:
     name: Regenerate Visual Snapshots


### PR DESCRIPTION
Every push re-triggers CI, deploy, and the auto-commit workflows, but
none had a concurrency group, so rapid commits/PRs left stale runs
piling up alongside newer ones instead of being superseded.

- backend-ci, frontend-ci, and the three auto-commit workflows now
  cancel in-progress runs for the same branch/PR when a newer commit
  lands, since only the latest run's result matters.
- deploy.yml queues instead of cancelling, since aborting a live
  CapRover deploy mid-flight could leave the app in a broken state.