### PR TITLE
Fix home preferences toggle/reorder not persisting from a warm query cache

### DIFF
--- a/anything-frontend/src/app/home-preferences/page.test.tsx
+++ b/anything-frontend/src/app/home-preferences/page.test.tsx
@@ -1,5 +1,7 @@
-import { screen, waitFor } from '@testing-library/react'
+import { render as rtlRender, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { PageActionsProvider } from '@/context/PageActionsContext'
 import { render } from '@/__tests__/utils/test-utils'
 import HomePreferencesPage from './page'
 
@@ -103,6 +105,47 @@ describe('HomePreferencesPage', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Go back' })).toBeInTheDocument()
+    })
+  })
+
+  // Regression test: the real app's QueryProvider sets staleTime to 60s, so a
+  // component that mounts after another page already fetched card preferences
+  // (e.g. navigating here from the home page, which also calls
+  // useHomeCardPreferences) sees cached, non-stale data with no new fetch/render
+  // in between. Local `cards` state must still seed from that cached data —
+  // otherwise toggle and drag silently no-op because they bail out on `!cards`.
+  it('should allow toggling and reordering when preferences are already cached (warm query cache)', async () => {
+    const user = userEvent.setup()
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { staleTime: 60 * 1000 } },
+    })
+    queryClient.setQueryData(['homeCardPreferences'], [
+      { cardKey: 'foodplan', sortOrder: 0, isVisible: true },
+      { cardKey: 'lists', sortOrder: 1, isVisible: true },
+      { cardKey: 'bills', sortOrder: 2, isVisible: true },
+    ])
+
+    rtlRender(
+      <QueryClientProvider client={queryClient}>
+        <PageActionsProvider>
+          <HomePreferencesPage />
+        </PageActionsProvider>
+      </QueryClientProvider>
+    )
+
+    // Data is served from cache synchronously, so the row is present immediately.
+    expect(screen.getByText('Lists')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('switch', { name: 'Show Lists on home page' }))
+
+    await waitFor(() => {
+      expect(mockCardPreferencesPut).toHaveBeenCalledWith({
+        cards: [
+          { cardKey: 'foodplan', isVisible: true },
+          { cardKey: 'lists', isVisible: false },
+          { cardKey: 'bills', isVisible: true },
+        ],
+      })
     })
   })
 })

--- a/anything-frontend/src/app/home-preferences/page.tsx
+++ b/anything-frontend/src/app/home-preferences/page.tsx
@@ -79,7 +79,6 @@ export default function HomePreferencesPage() {
   const updatePreferences = useUpdateHomeCardPreferences();
   const { setLeftAction } = useHeaderActions();
   const [cards, setCards] = useState<CardPreference[] | null>(null);
-  const [syncedData, setSyncedData] = useState(data);
 
   useEffect(() => {
     setLeftAction({ type: "back", href: "/" });
@@ -87,13 +86,15 @@ export default function HomePreferencesPage() {
   }, [setLeftAction]);
 
   // Seed local (draggable) state from the fetched preferences the first time they arrive,
-  // without clobbering in-flight local edits on subsequent refetches.
-  if (data !== syncedData) {
-    setSyncedData(data);
+  // without clobbering in-flight local edits on subsequent refetches. Keyed on `data` itself
+  // (not just a reference change) so this still fires when `data` is served from a warm
+  // react-query cache (e.g. navigating here from the home page, which already fetched it).
+  useEffect(() => {
     if (cards === null && data) {
       setCards(data.map((p) => ({ cardKey: p.cardKey as HomeCardKey, isVisible: p.isVisible ?? true })));
     }
-  }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only seed once; `cards` is deliberately omitted to avoid re-running on every local edit
+  }, [data]);
 
   const sensors = useSensors(
     useSensor(PointerSensor),


### PR DESCRIPTION
The home-preferences page only seeded its local draggable/toggle state
when the useHomeCardPreferences() data object changed reference. Since
the QueryProvider sets a 60s staleTime and the home page already fetches
the same query, navigating here shortly after visiting home hits a warm
cache whose data reference never changes — so local state stayed null
forever and every toggle/drag silently no-op'd (both handlers bail out
on `!cards`).

Seed local state from a proper effect keyed on `data` itself instead of
a reference-equality check, so it fires whenever preferences are
available, cached or not. Added a regression test that pre-populates
the query cache before mount to cover this exact scenario.