### PR TITLE
Fix offline mutations getting stuck paused by React Query's networkMode

### DIFF
--- a/anything-frontend/src/context/QueryProvider.test.tsx
+++ b/anything-frontend/src/context/QueryProvider.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useMutation } from "@tanstack/react-query";
+import { QueryProvider } from "@/context/QueryProvider";
+
+function setOnline(value: boolean) {
+  Object.defineProperty(navigator, "onLine", { configurable: true, value });
+}
+
+// React Query's default networkMode ("online") pauses mutationFn until the
+// browser's online event fires, based on its own onlineManager rather than
+// the app's isOffline() checks. Our offline queueing (useShoppingLists.ts:
+// isOffline() -> enqueueAdd/enqueueUpdate/enqueueDelete) relies on mutationFn
+// actually running while offline, so QueryProvider must opt mutations out of
+// that gating. Jest/jsdom-only tests that merely stub navigator.onLine
+// (without dispatching a real event) can't catch a regression here because
+// React Query's onlineManager only reacts to the actual browser event —
+// exactly what Playwright's context().setOffline(true) fires for real,
+// which is what originally exposed this in e2e/offline.spec.ts.
+describe("QueryProvider mutation network mode", () => {
+  afterEach(() => {
+    setOnline(true);
+    window.dispatchEvent(new Event("online"));
+  });
+
+  it("still invokes mutationFn after a real browser offline event", async () => {
+    const mutationFn = jest.fn<Promise<string>, []>().mockResolvedValue("done");
+    const { result } = renderHook(() => useMutation({ mutationFn }), {
+      wrapper: QueryProvider,
+    });
+
+    // QueryClientProvider subscribes to React Query's onlineManager only once
+    // mounted (in a useEffect), so the offline event must be dispatched after
+    // that mount — otherwise it's missed and isOnline() never flips, making
+    // this assert true regardless of networkMode.
+    act(() => {
+      setOnline(false);
+      window.dispatchEvent(new Event("offline"));
+    });
+
+    act(() => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mutationFn).toHaveBeenCalledTimes(1);
+    expect(result.current.isPaused).toBe(false);
+  });
+});

--- a/anything-frontend/src/context/QueryProvider.tsx
+++ b/anything-frontend/src/context/QueryProvider.tsx
@@ -19,6 +19,15 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
             staleTime: 60 * 1000,
             refetchOnWindowFocus: false,
           },
+          // Mutations implement their own offline handling (isOffline()/isNetworkError()
+          // checks that queue into the outbox — see useShoppingLists.ts). React Query's
+          // default networkMode "online" pauses mutationFn until the browser's online
+          // event fires, which would bypass that logic entirely: the mutation would sit
+          // paused while offline and only run once back online, when isOffline() already
+          // reports false and it goes straight to the network instead of the outbox.
+          mutations: {
+            networkMode: "always",
+          },
         },
       })
   );


### PR DESCRIPTION
React Query's default networkMode ("online") pauses mutationFn until the
browser's online event fires, gated by its own onlineManager rather than
the app's isOffline() checks. That meant useShoppingLists.ts's offline
queueing (isOffline() -> enqueueAdd/enqueueUpdate/enqueueDelete) never
actually ran while genuinely offline: the mutation just sat paused and
only executed once back online, when isOffline() already reports false
and it goes straight to the network instead of the outbox. This is why
the "Pending sync" indicator never appeared in e2e/offline.spec.ts.

Set mutations.networkMode to "always" in QueryProvider so mutationFn
always runs immediately and the app's own connectivity handling takes
over, as designed.

Added a regression test that dispatches a real browser offline event
(existing tests only stubbed navigator.onLine without dispatching the
event, so React Query's onlineManager never observed the change and
the bug went uncaught).