### PR TITLE
Improve OCR ingredient-vs-instruction classification

### DIFF
--- a/anything-frontend/src/lib/ocr.test.ts
+++ b/anything-frontend/src/lib/ocr.test.ts
@@ -7,7 +7,7 @@ describe("classifyOcrLines", () => {
     expect(result.name).toBe("Pandekager");
   });
 
-  it("classifies numeric and unit-prefixed lines as ingredients", () => {
+  it("splits quantity-led lines from instruction sentences", () => {
     const result = classifyOcrLines(
       [
         "Pandekager",
@@ -24,9 +24,9 @@ describe("classifyOcrLines", () => {
       "250 g mel",
       "½ tsk salt",
       "spsk sukker",
+      "en håndfuld hakkede mandler",
     ]);
     expect(result.stepsText.split("\n")).toEqual([
-      "en håndfuld hakkede mandler",
       "Whisk the flour, milk and eggs together until the batter is smooth.",
       "Fry thin pancakes on a hot pan.",
     ]);
@@ -46,6 +46,223 @@ describe("classifyOcrLines", () => {
       name: "",
       ingredientsText: "",
       stepsText: "",
+    });
+  });
+
+  describe("section headers", () => {
+    it("uses Danish headers as hard boundaries and drops the header lines", () => {
+      const result = classifyOcrLines(
+        [
+          "Pandekager",
+          "Ingredienser:",
+          "250 g mel",
+          "5 dl mælk",
+          "3 æg",
+          "Fremgangsmåde",
+          "Pisk æggene sammen med mælken.",
+          "Tilsæt melet lidt ad gangen.",
+          "Steg pandekagerne gyldne.",
+        ].join("\n")
+      );
+
+      expect(result.name).toBe("Pandekager");
+      expect(result.ingredientsText.split("\n")).toEqual(["250 g mel", "5 dl mælk", "3 æg"]);
+      expect(result.stepsText.split("\n")).toEqual([
+        "Pisk æggene sammen med mælken.",
+        "Tilsæt melet lidt ad gangen.",
+        "Steg pandekagerne gyldne.",
+      ]);
+    });
+
+    it("matches uppercase English headers with trailing punctuation", () => {
+      const result = classifyOcrLines(
+        [
+          "Banana bread",
+          "INGREDIENTS:",
+          "3 ripe bananas",
+          "1/2 cup melted butter",
+          "1 tsp baking soda",
+          "METHOD",
+          "Preheat the oven to 175 degrees.",
+          "Mash the bananas with the butter.",
+          "Bake for one hour.",
+        ].join("\n")
+      );
+
+      expect(result.name).toBe("Banana bread");
+      expect(result.ingredientsText.split("\n")).toEqual([
+        "3 ripe bananas",
+        "1/2 cup melted butter",
+        "1 tsp baking soda",
+      ]);
+      expect(result.stepsText.split("\n")).toEqual([
+        "Preheat the oven to 175 degrees.",
+        "Mash the bananas with the butter.",
+        "Bake for one hour.",
+      ]);
+    });
+
+    it("accepts OCR-transliterated Danish headers (å read as aa)", () => {
+      const result = classifyOcrLines(
+        ["Suppe", "Ingredienser", "2 ds tomater", "Fremgangsmaade", "Hak grøntsagerne."].join("\n")
+      );
+
+      expect(result.ingredientsText).toBe("2 ds tomater");
+      expect(result.stepsText).toBe("Hak grøntsagerne.");
+    });
+
+    it("leaves the name empty when the text starts with a header", () => {
+      const result = classifyOcrLines("Ingredienser\n2 dl fløde\n1 tsk vanilje");
+
+      expect(result.name).toBe("");
+      expect(result.ingredientsText.split("\n")).toEqual(["2 dl fløde", "1 tsk vanilje"]);
+      expect(result.stepsText).toBe("");
+    });
+
+    it("splits a trailing ingredients section that runs into unlabeled instructions", () => {
+      const result = classifyOcrLines(
+        [
+          "Æblekage",
+          "Ingredienser",
+          "6 æbler",
+          "100 g sukker",
+          "Skræl æblerne og skær dem i både.",
+          "Kog æblerne møre med sukkeret.",
+        ].join("\n")
+      );
+
+      expect(result.ingredientsText.split("\n")).toEqual(["6 æbler", "100 g sukker"]);
+      expect(result.stepsText.split("\n")).toEqual([
+        "Skræl æblerne og skær dem i både.",
+        "Kog æblerne møre med sukkeret.",
+      ]);
+    });
+
+    it("keeps ambiguous short lines under an ingredients header as ingredients", () => {
+      const result = classifyOcrLines("Dressing\nIngredienser\nsalt\npeber\ncitronsaft");
+
+      expect(result.ingredientsText.split("\n")).toEqual(["salt", "peber", "citronsaft"]);
+      expect(result.stepsText).toBe("");
+    });
+  });
+
+  describe("headerless segmentation", () => {
+    it("classifies numbered instructions as steps, not ingredients", () => {
+      const result = classifyOcrLines(
+        [
+          "Tomato soup",
+          "2 cans tomatoes",
+          "1 onion",
+          "2 tbsp olive oil",
+          "1. Chop the onion finely.",
+          "2. Heat the oil in a large pot.",
+          "3. Add the tomatoes and simmer for 20 minutes.",
+        ].join("\n")
+      );
+
+      expect(result.ingredientsText.split("\n")).toEqual([
+        "2 cans tomatoes",
+        "1 onion",
+        "2 tbsp olive oil",
+      ]);
+      expect(result.stepsText.split("\n")).toEqual([
+        "1. Chop the onion finely.",
+        "2. Heat the oil in a large pot.",
+        "3. Add the tomatoes and simmer for 20 minutes.",
+      ]);
+    });
+
+    it("recognizes imperative Danish verbs as step starts", () => {
+      const result = classifyOcrLines(
+        [
+          "Boller",
+          "500 g mel",
+          "50 g gær",
+          "3 dl mælk",
+          "Rør gæren ud i mælken.",
+          "Ælt dejen godt.",
+          "Lad dejen hæve i en time.",
+          "Bag ved 220 grader.",
+        ].join("\n")
+      );
+
+      expect(result.ingredientsText.split("\n")).toEqual(["500 g mel", "50 g gær", "3 dl mælk"]);
+      expect(result.stepsText.split("\n")).toEqual([
+        "Rør gæren ud i mælken.",
+        "Ælt dejen godt.",
+        "Lad dejen hæve i en time.",
+        "Bag ved 220 grader.",
+      ]);
+    });
+
+    it("absorbs a stray misread line into the surrounding steps block", () => {
+      const result = classifyOcrLines(
+        [
+          "Kage",
+          "200 g smør",
+          "2 dl sukker",
+          "Rør smørret blødt.",
+          "kagen bages",
+          "Sæt i ovnen.",
+        ].join("\n")
+      );
+
+      expect(result.ingredientsText.split("\n")).toEqual(["200 g smør", "2 dl sukker"]);
+      expect(result.stepsText.split("\n")).toEqual([
+        "Rør smørret blødt.",
+        "kagen bages",
+        "Sæt i ovnen.",
+      ]);
+    });
+
+    it("handles bulleted ingredients and ascii fractions", () => {
+      const result = classifyOcrLines(
+        [
+          "Krydderkage",
+          "- 1/2 tsk kanel",
+          "- 1 1/2 dl fløde",
+          "• 2 spsk honning",
+          "Bland det hele og bag kagen.",
+        ].join("\n")
+      );
+
+      expect(result.ingredientsText.split("\n")).toEqual([
+        "- 1/2 tsk kanel",
+        "- 1 1/2 dl fløde",
+        "• 2 spsk honning",
+      ]);
+      expect(result.stepsText).toBe("Bland det hele og bag kagen.");
+    });
+
+    it("keeps a trailing note with the steps", () => {
+      const result = classifyOcrLines(
+        [
+          "Suppe",
+          "2 l vand",
+          "1 løg",
+          "Kog vandet op med løget.",
+          "Server suppen rygende varm.",
+          "Kan opbevares i køleskabet i tre dage.",
+        ].join("\n")
+      );
+
+      expect(result.ingredientsText.split("\n")).toEqual(["2 l vand", "1 løg"]);
+      expect(result.stepsText.split("\n")).toEqual([
+        "Kog vandet op med løget.",
+        "Server suppen rygende varm.",
+        "Kan opbevares i køleskabet i tre dage.",
+      ]);
+    });
+
+    it("puts everything after the name into steps when nothing looks like an ingredient", () => {
+      const result = classifyOcrLines(
+        "Grandmas trick\nAlways rest the dough overnight before you bake it in the morning."
+      );
+
+      expect(result.ingredientsText).toBe("");
+      expect(result.stepsText).toBe(
+        "Always rest the dough overnight before you bake it in the morning."
+      );
     });
   });
 });

--- a/anything-frontend/src/lib/ocr.ts
+++ b/anything-frontend/src/lib/ocr.ts
@@ -85,24 +85,139 @@ const UNIT_TOKENS = new Set([
   "can", "cans", "pinch", "handful", "dash", "slice", "slices", "piece", "pieces",
 ]);
 
-const NUMERIC_START = /^[\d¼½¾⅓⅔⅛]/;
+// Printed recipes usually label their sections; an exact header match is the
+// strongest classification signal available. Matched after lowercasing and
+// stripping trailing punctuation, so "INGREDIENSER:" hits "ingredienser".
+const INGREDIENT_HEADERS = new Set([
+  "ingredienser", "ingredients", "du skal bruge", "det skal du bruge",
+]);
+const STEP_HEADERS = new Set([
+  "fremgangsmåde", "tilberedning", "sådan gør du", "sådan gør man",
+  "instructions", "method", "directions", "steps", "preparation",
+  // OCR frequently misreads å/ø; accept common transliterations.
+  "fremgangsmaade", "fremgangsmade", "sadan gor du", "saadan goer du",
+]);
+const MAX_HEADER_LENGTH = 32;
+
+// Steps are imperative sentences; their first word is a cooking verb.
+const STEP_VERBS = new Set([
+  // Danish
+  "rør", "bland", "pisk", "steg", "bag", "hæld", "tilsæt", "kom", "varm",
+  "opvarm", "forvarm", "skær", "hak", "lad", "smelt", "server", "servér",
+  "anret", "fordel", "vend", "dæk", "stil", "sæt", "tag", "kog", "bring",
+  "drys", "smag", "riv", "pensl", "mos", "si", "afkøl", "ælt", "skræl",
+  // English
+  "whisk", "mix", "stir", "add", "heat", "bake", "fry", "pour", "combine",
+  "let", "melt", "serve", "preheat", "place", "put", "remove", "cut", "chop",
+  "slice", "season", "cover", "boil", "simmer", "cook", "drain", "transfer",
+  "sprinkle", "spread", "fold", "beat", "knead", "cool", "garnish", "repeat",
+  "flip", "reduce", "blend", "mash",
+]);
+
+// "250", "1,5", "1/2", "1 1/2", "½", "1 ½"
+const LEADING_QUANTITY =
+  /^(\d+\s+\d+\/\d+|\d+\s+[¼½¾⅓⅔⅛⅜⅝⅞]|\d+\/\d+|\d+(?:[.,]\d+)?|[¼½¾⅓⅔⅛⅜⅝⅞])/;
+// "1. " / "3) " enumeration, as used for numbered instructions
+const NUMBERED_STEP_PREFIX = /^\d{1,2}[.)]\s+/;
+const LEADING_BULLET = /^[-–•*·]\s*/;
 const MAX_INGREDIENT_LINE_LENGTH = 60;
 
-function looksLikeIngredient(line: string): boolean {
-  if (NUMERIC_START.test(line)) return true;
-  if (line.length > MAX_INGREDIENT_LINE_LENGTH) return false;
-  return line
-    .toLowerCase()
-    .split(/\s+/)
-    .slice(0, 2)
-    .some((word) => UNIT_TOKENS.has(word.replace(/[.,]$/, "")));
+const stripWordPunctuation = (word: string): string => word.replace(/[.,:;!?]+$/, "");
+
+function startsWithQuantityAndUnit(text: string): boolean {
+  const quantity = LEADING_QUANTITY.exec(text);
+  if (!quantity) return false;
+  const nextWord = text.slice(quantity[0].length).trimStart().split(/\s+/)[0];
+  return UNIT_TOKENS.has(stripWordPunctuation(nextWord ?? "").toLowerCase());
+}
+
+function headerLabel(line: string): "ingredients" | "steps" | null {
+  const normalized = stripWordPunctuation(line.trim()).toLowerCase();
+  if (normalized.length > MAX_HEADER_LENGTH) return null;
+  if (INGREDIENT_HEADERS.has(normalized)) return "ingredients";
+  if (STEP_HEADERS.has(normalized)) return "steps";
+  return null;
 }
 
 /**
- * Crude prefill classifier for OCR output: first non-empty line becomes the
- * name, short/numeric lines become ingredients, the rest become steps. The
- * user reviews and corrects the result before importing, so this only needs
- * to be a decent starting point.
+ * Signed ingredient-likelihood score for one line: positive means
+ * ingredient-ish, negative means instruction-ish, magnitude is confidence.
+ */
+function scoreLine(rawLine: string): number {
+  const line = rawLine.trim();
+  const bulleted = LEADING_BULLET.test(line);
+  const body = line.replace(LEADING_BULLET, "");
+  let score = bulleted ? 1 : 0;
+
+  const numbered = NUMBERED_STEP_PREFIX.exec(body);
+  const unnumberedBody = numbered ? body.slice(numbered[0].length) : body;
+  if (numbered) {
+    // "1. Whisk the flour…" is an enumerated instruction, but "1. 2 dl mælk"
+    // is an enumerated ingredient.
+    score += startsWithQuantityAndUnit(unnumberedBody) ? 1 : -3;
+  } else if (LEADING_QUANTITY.test(body)) {
+    score += startsWithQuantityAndUnit(body) ? 3 : 1;
+  }
+
+  const words = unnumberedBody
+    .toLowerCase()
+    .split(/\s+/)
+    .map(stripWordPunctuation)
+    .filter((word) => word.length > 0);
+  const firstWord = words[0] ?? "";
+
+  if (!numbered && !LEADING_QUANTITY.test(body) && words.slice(0, 2).some((word) => UNIT_TOKENS.has(word))) {
+    score += 1;
+  }
+  if (STEP_VERBS.has(firstWord)) score -= 3;
+  if (line.length > MAX_INGREDIENT_LINE_LENGTH) score -= 1;
+  if (words.length > 8) score -= 1;
+  if (/[.!]$/.test(line)) score -= 0.5;
+  if (words.length <= 5 && !STEP_VERBS.has(firstWord)) score += 0.5;
+
+  return score;
+}
+
+/**
+ * Split a run of unlabeled lines into a contiguous ingredients block followed
+ * by a contiguous steps block — recipes virtually always list ingredients
+ * first, and contiguity lets confidently-scored neighbours absorb the odd
+ * ambiguous or misread line instead of flipping category mid-block.
+ *
+ * Picks the split index maximising (sum of scores before it) − (sum after
+ * it), which reduces to maximising the prefix sum. `preferIngredients`
+ * controls tie-breaking: sections introduced by an "Ingredienser" header
+ * default to ingredients, headerless text defaults to steps.
+ */
+function bestSplit(
+  lines: string[],
+  preferIngredients: boolean
+): { ingredients: string[]; steps: string[] } {
+  const scores = lines.map(scoreLine);
+  let splitIndex = 0;
+  let bestPrefixSum = 0;
+  let prefixSum = 0;
+  for (let k = 1; k <= lines.length; k++) {
+    prefixSum += scores[k - 1];
+    if (prefixSum > bestPrefixSum || (preferIngredients && prefixSum === bestPrefixSum)) {
+      bestPrefixSum = prefixSum;
+      splitIndex = k;
+    }
+  }
+  return { ingredients: lines.slice(0, splitIndex), steps: lines.slice(splitIndex) };
+}
+
+interface Section {
+  label: "ingredients" | "steps" | null;
+  lines: string[];
+}
+
+/**
+ * Prefill classifier for OCR output: the first line becomes the name, then
+ * lines are split into ingredients and steps using printed section headers
+ * where present and scored contiguous segmentation where not. The user
+ * reviews and corrects the result before importing, so this only needs to be
+ * a good starting point, not perfect.
  */
 export function classifyOcrLines(text: string): ClassifiedRecipeText {
   const lines = text
@@ -110,17 +225,36 @@ export function classifyOcrLines(text: string): ClassifiedRecipeText {
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
 
-  const name = lines.shift() ?? "";
-  const ingredients: string[] = [];
-  const steps: string[] = [];
-
+  let name = "";
+  const sections: Section[] = [{ label: null, lines: [] }];
   for (const line of lines) {
-    if (looksLikeIngredient(line)) {
-      ingredients.push(line);
+    const label = headerLabel(line);
+    if (label) {
+      sections.push({ label, lines: [] });
+    } else if (!name && sections.length === 1 && sections[0].lines.length === 0) {
+      name = line;
     } else {
-      steps.push(line);
+      sections[sections.length - 1].lines.push(line);
     }
   }
+
+  const ingredients: string[] = [];
+  const steps: string[] = [];
+  sections.forEach((section, index) => {
+    if (section.lines.length === 0) return;
+    const isLastSection = index === sections.length - 1;
+    if (section.label === "steps") {
+      steps.push(...section.lines);
+    } else if (section.label === "ingredients" && !isLastSection) {
+      ingredients.push(...section.lines);
+    } else {
+      // Headerless text, a preamble, or a trailing "Ingredienser" section
+      // that may run straight into unlabeled instructions.
+      const split = bestSplit(section.lines, section.label === "ingredients");
+      ingredients.push(...split.ingredients);
+      steps.push(...split.steps);
+    }
+  });
 
   return {
     name,


### PR DESCRIPTION
## Description
Follow-up to #619: replaces the crude per-line heuristic in `classifyOcrLines` (`anything-frontend/src/lib/ocr.ts`) with a three-stage classification pipeline for OCR'd recipe text:

1. **Section headers as hard boundaries** — printed headers like "Ingredienser", "Fremgangsmåde", "Ingredients", "Method" (matched case-insensitively, trailing punctuation stripped, including common OCR transliterations of å/ø such as "Fremgangsmaade") assign every line in their section and are dropped from the output.
2. **Multi-signal line scoring** — leading quantity + unit is strongly ingredient-ish; numbered prefixes ("1. Whisk…") are strongly step-ish; imperative cooking verbs (Danish + English lexicon), bullets, line length, and terminal punctuation all contribute a signed score.
3. **Contiguous best-split segmentation** — picks the single ingredients/steps boundary that maximizes total score agreement (prefix-sum scan), so a stray misread line is absorbed by its confident neighbours instead of flipping category mid-block.

Fixes the worst defect of the old heuristic: numbered instructions ("1. Chop the onion…") were misclassified as ingredients because they start with a digit.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/modification
- [ ] CI/CD changes

## Testing
- [x] Backend tests pass locally (no backend changes — frontend-only)
- [x] Frontend builds successfully (`npm run build`, `npm run lint` clean)
- [x] Manual testing performed (drove the scan-from-photo flow in a real browser against `next dev`; a generated Danish recipe photo with "Ingredienser:"/"Fremgangsmåde" headers and numbered steps classified perfectly end-to-end)
- [x] New tests added (12 new Jest corpus cases covering Danish/English headers, transliterated headers, numbered steps, imperative verbs, bullets/fractions, stray OCR noise absorption, trailing notes; full suite 757 passing)

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Related Issues
None.

## Screenshots (if applicable)
No UI changes — the review screen is unchanged; only its prefilled content improves.

## Additional Notes
Known remaining limitation (unchanged from #619): two-column cookbook layouts interleave lines in OCR output, which no line-based classifier can untangle — handling that would require tesseract's block/bbox layout data and is left as a future option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ye7YsBw5VqG4UDr2cNUBS

---
_Generated by [Claude Code](https://claude.ai/code/session_014ye7YsBw5VqG4UDr2cNUBS)_