### PR TITLE
Fix stale reads after reload from the persisted React Query cache

### DIFF
--- a/anything-frontend/src/context/QueryProvider.tsx
+++ b/anything-frontend/src/context/QueryProvider.tsx
@@ -43,6 +43,16 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
           shouldDehydrateQuery: shouldPersistQuery,
         },
       }}
+      // Restored queries keep their original dataUpdatedAt, so with a 60s
+      // staleTime they can read as "fresh" — and skip refetching — for up to
+      // a minute after a reload even though the persisted snapshot predates
+      // writes made just before the reload (a mutation's cache update can
+      // land after the persister's last throttled flush). Invalidating once
+      // restore completes forces every query to revalidate against the
+      // server instead of trusting a snapshot that may already be stale.
+      onSuccess={() => {
+        void queryClient.invalidateQueries();
+      }}
     >
       {children}
       <ReactQueryDevtools initialIsOpen={false} />


### PR DESCRIPTION
PersistQueryClientProvider restores queries with their original
dataUpdatedAt, so with the 60s staleTime a restored snapshot reads as
"fresh" and skips refetching for up to a minute — even when the
persister's throttled (1s) write missed a mutation made right before
the reload. This made shopping-list items just-added-then-reloaded
disappear in the deploy e2e run (real network latency changes the
timing enough to hit the race consistently there, though it can occur
anywhere) — e2e/shopping-lists.spec.ts and e2e/offline.spec.ts both
reload right after adding/syncing an item and then assert it's visible.

Invalidate all queries once the persisted cache finishes restoring so
every query revalidates against the server instead of trusting a
snapshot that may already be stale.