### PR TITLE
Fix e2e navigation test for consolidated suggestions admin

The "Suggestion Categories page loads" nav test still pointed at the removed
/lists/suggestions/categories route and asserted an <h1>Suggestion Categories</h1>
that no longer exists — categories is now a tab on the Suggestions admin page.
Drop it from the generic page loop and add a dedicated test that opens
?tab=categories and asserts the page heading ("Suggestions") plus the active
Categories tab. This is the functional counterpart to the visual-spec updates
that already moved to the tabbed layout.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HvokcwBrwyov6e1pa59YtG

### DIFF
--- a/anything-frontend/e2e/navigation.spec.ts
+++ b/anything-frontend/e2e/navigation.spec.ts
@@ -31,7 +31,6 @@ for (const { path, title } of PAGES) {
 
 const HOUSEHOLD_CONFIG_PAGES = [
   { subPath: "/lists/suggestions", title: "Suggestions" },
-  { subPath: "/lists/suggestions/categories", title: "Suggestion Categories" },
   { subPath: "/recipes/tags", title: "Recipe Tags" },
 ];
 
@@ -47,6 +46,22 @@ for (const { subPath, title } of HOUSEHOLD_CONFIG_PAGES) {
     ).toBeVisible();
   });
 }
+
+test("Suggestions categories tab loads without errors", async ({ page }) => {
+  // Categories are now a tab on the consolidated Suggestions admin page
+  // (reached via ?tab=categories), not a separate route. The page heading
+  // stays "Suggestions"; the Categories tab becomes the active tab.
+  await page.goto("/");
+  const householdId = await page.evaluate(() => localStorage.getItem("householdId"));
+  await page.goto(`/households/${householdId}/lists/suggestions?tab=categories`);
+  await expect(page).not.toHaveURL(/\/error/);
+  await expect(
+    page.getByRole("heading", { name: "Suggestions", level: 1 })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("tab", { name: /Categories/ })
+  ).toHaveAttribute("aria-selected", "true");
+});
 
 test("unauthenticated access redirects to login", async ({ browser }) => {
   // Explicitly pass an empty storageState to override the project-level storageState


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/modification
- [ ] CI/CD changes

## Testing
<!-- Describe the tests you ran and/or how to test your changes -->
- [ ] Backend tests pass locally
- [ ] Frontend builds successfully
- [ ] Manual testing performed
- [ ] New tests added (if applicable)

## Checklist
<!-- Mark completed items with an 'x' -->
- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues
<!-- Link to related issues using #issue_number -->
Closes #

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any other context about the PR here -->
