### PR TITLE
Fix household search index page scoping to route household

### DIFF
--- a/anything-frontend/src/app/households/[id]/search/page.test.tsx
+++ b/anything-frontend/src/app/households/[id]/search/page.test.tsx
@@ -8,6 +8,7 @@ const mockOverviewGet = jest.fn();
 const mockRebuildHouseholdPost = jest.fn();
 
 jest.mock("@/lib/apiClient", () => ({
+  HOUSEHOLD_HEADER: "X-Household-Id",
   apiClient: {
     api: {
       search: {
@@ -20,6 +21,12 @@ jest.mock("@/lib/apiClient", () => ({
   },
 }));
 
+// The route [id] (2) intentionally differs from the active household (1, from the
+// HouseholdContext mock below) so tests prove the calls are scoped to the URL, not
+// the globally-active household.
+const ROUTE_HOUSEHOLD_ID = "2";
+const EXPECTED_SCOPED_CONFIG = { headers: { "X-Household-Id": ROUTE_HOUSEHOLD_ID } };
+
 jest.mock("sonner", () => ({
   toast: { success: jest.fn(), error: jest.fn() },
   Toaster: () => null,
@@ -28,8 +35,8 @@ jest.mock("sonner", () => ({
 const mockPush = jest.fn();
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush, replace: jest.fn(), back: jest.fn() }),
-  useParams: () => ({ id: "1" }),
-  usePathname: () => "/households/1/search",
+  useParams: () => ({ id: "2" }),
+  usePathname: () => "/households/2/search",
 }));
 
 const mockGetHouseholdRole = jest.fn();
@@ -76,6 +83,8 @@ describe("HouseholdSearchIndexPage", () => {
       await waitFor(() => {
         expect(toast.success).toHaveBeenCalledWith("Rebuilt search index for 7 items.");
       });
+      // The rebuild must target the household in the route, not the active one.
+      expect(mockRebuildHouseholdPost).toHaveBeenCalledWith(EXPECTED_SCOPED_CONFIG);
     });
 
     it("shows an error toast when the rebuild fails", async () => {
@@ -154,6 +163,8 @@ describe("HouseholdSearchIndexPage", () => {
       expect(screen.getByText("ShoppingList")).toBeInTheDocument();
       expect(screen.getByText("2")).toBeInTheDocument();
       expect(screen.getByText("5")).toBeInTheDocument();
+      // The overview must be fetched for the household in the route, not the active one.
+      expect(mockOverviewGet).toHaveBeenCalledWith(EXPECTED_SCOPED_CONFIG);
     });
   });
 });

--- a/anything-frontend/src/app/households/[id]/search/page.tsx
+++ b/anything-frontend/src/app/households/[id]/search/page.tsx
@@ -18,10 +18,12 @@ export default function HouseholdSearchIndexPage() {
   const router = useRouter();
   const params = useParams();
   const householdId = typeof params.id === "string" ? params.id : "";
+  const routeHouseholdId = Number(householdId);
+  const scopedHouseholdId = Number.isNaN(routeHouseholdId) ? undefined : routeHouseholdId;
   const { getHouseholdRole, isLoading: householdsLoading } = useHouseholdContext();
   const { setLeftAction } = useHeaderActions();
-  const { data: overview, isLoading } = useSearchIndexOverview();
-  const rebuildIndex = useRebuildHouseholdSearchIndex();
+  const { data: overview, isLoading } = useSearchIndexOverview(scopedHouseholdId);
+  const rebuildIndex = useRebuildHouseholdSearchIndex(scopedHouseholdId);
   const isOnline = useOnlineStatus();
 
   useEffect(() => {

--- a/anything-frontend/src/hooks/useSearch.ts
+++ b/anything-frontend/src/hooks/useSearch.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { apiClient } from "@/lib/apiClient";
+import { apiClient, HOUSEHOLD_HEADER } from "@/lib/apiClient";
 import type {
   SearchResultResponse,
   SearchIndexOverviewResponse,
@@ -11,6 +11,17 @@ import type {
 export type { SearchResultResponse, SearchIndexOverviewResponse, RebuildSearchIndexResponse };
 
 const SEARCH_INDEX_OVERVIEW_KEY = ["searchIndexOverview"] as const;
+
+/**
+ * Builds a Kiota request configuration that pins the call to a specific
+ * household via the X-Household-Id header, overriding the active household the
+ * apiClient would otherwise inject. Returns undefined when no id is given so
+ * the request keeps the default active-household behaviour.
+ */
+function householdRequestConfig(householdId?: number) {
+  if (householdId === undefined || Number.isNaN(householdId)) return undefined;
+  return { headers: { [HOUSEHOLD_HEADER]: String(householdId) } };
+}
 
 /** Cross-entity search. Pass an already-debounced term; disabled while blank. */
 export function useSearch(term: string, limit = 20) {
@@ -30,12 +41,16 @@ export function useSearch(term: string, limit = 20) {
   });
 }
 
-/** Household-scoped "is search populated/healthy" summary — counts by entity type, gated to household managers on the backend. */
-export function useSearchIndexOverview() {
+/**
+ * Household-scoped "is search populated/healthy" summary — counts by entity type,
+ * gated to household managers on the backend. Pass an explicit `householdId` to scope
+ * the call to that household (e.g. from a route) instead of the active household.
+ */
+export function useSearchIndexOverview(householdId?: number) {
   return useQuery({
-    queryKey: SEARCH_INDEX_OVERVIEW_KEY,
+    queryKey: [...SEARCH_INDEX_OVERVIEW_KEY, householdId ?? null],
     queryFn: async (): Promise<SearchIndexOverviewResponse> => {
-      const overview = await apiClient.api.search.overview.get();
+      const overview = await apiClient.api.search.overview.get(householdRequestConfig(householdId));
       return overview ?? { totalDocuments: 0, byType: [], lastIndexedOn: null };
     },
   });
@@ -56,13 +71,19 @@ export function useRebuildSearchIndex() {
   });
 }
 
-/** Household-manager self-serve: rebuilds only the caller's own household. */
-export function useRebuildHouseholdSearchIndex() {
+/**
+ * Household-manager self-serve: rebuilds a single household's index. Pass an explicit
+ * `householdId` (e.g. from a route) to scope the rebuild to that household instead of
+ * the active one; the backend still enforces the caller's manager role in it.
+ */
+export function useRebuildHouseholdSearchIndex(householdId?: number) {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (): Promise<RebuildSearchIndexResponse> => {
-      const result = await apiClient.api.search.rebuildIndex.household.post();
+      const result = await apiClient.api.search.rebuildIndex.household.post(
+        householdRequestConfig(householdId)
+      );
       return result ?? { indexed: 0 };
     },
     onSuccess: () => {

--- a/anything-frontend/src/lib/apiClient.test.ts
+++ b/anything-frontend/src/lib/apiClient.test.ts
@@ -184,6 +184,19 @@ describe("HouseholdHeaderHandler", () => {
     expect(headers.get(HOUSEHOLD_HEADER)).toBeNull();
   });
 
+  it("preserves an explicit X-Household-Id header instead of overriding it with the active household", async () => {
+    localStorage.setItem(HOUSEHOLD_ID_KEY, "1");
+
+    const explicitHeaders = new Headers();
+    explicitHeaders.set(HOUSEHOLD_HEADER, "2");
+    await handler.execute("https://api.example.com/test", { headers: explicitHeaders });
+
+    const calledInit = mockNext.execute.mock.calls[0][1] as RequestInit;
+    const headers = new Headers(calledInit.headers as HeadersInit);
+    // The per-request household (2) must win over the active household (1).
+    expect(headers.get(HOUSEHOLD_HEADER)).toBe("2");
+  });
+
   it("passes through to next middleware", async () => {
     localStorage.setItem(HOUSEHOLD_ID_KEY, "7");
 

--- a/anything-frontend/src/lib/apiClient.ts
+++ b/anything-frontend/src/lib/apiClient.ts
@@ -124,14 +124,19 @@ export class HouseholdHeaderHandler implements Middleware {
     requestInit: RequestInit,
     requestOptions?: Record<string, RequestOption>
   ): Promise<Response> {
-    const householdId =
-      typeof window !== "undefined"
-        ? localStorage.getItem(HOUSEHOLD_ID_KEY)
-        : null;
-    if (householdId) {
-      const headers = new Headers(requestInit.headers as HeadersInit);
-      headers.set(HOUSEHOLD_HEADER, householdId);
-      requestInit = { ...requestInit, headers };
+    const headers = new Headers(requestInit.headers as HeadersInit);
+    // Respect an explicit per-request X-Household-Id (e.g. a page scoped to a
+    // household from the route). Only fall back to the active household from
+    // localStorage when the caller hasn't set one, so we never override it.
+    if (!headers.has(HOUSEHOLD_HEADER)) {
+      const householdId =
+        typeof window !== "undefined"
+          ? localStorage.getItem(HOUSEHOLD_ID_KEY)
+          : null;
+      if (householdId) {
+        headers.set(HOUSEHOLD_HEADER, householdId);
+        requestInit = { ...requestInit, headers };
+      }
     }
     const response = await this.next?.execute(url, requestInit, requestOptions);
     if (!response) {


### PR DESCRIPTION
The /households/[id]/search page read and rebuilt the search index for the
globally-active household (from localStorage) rather than the household in the
URL. HouseholdHeaderHandler unconditionally overwrote X-Household-Id with the
active household, so the overview counts and the Rebuild action could target the
wrong household while the page appeared to be for [id].

- apiClient: only inject the active household's X-Household-Id when the request
  hasn't already set one, so an explicit per-request override wins.
- useSearch: useSearchIndexOverview / useRebuildHouseholdSearchIndex accept an
  optional householdId and pin the call to it via the X-Household-Id header; the
  overview query key includes the id so switching households refetches.
- household search page: pass the route [id] to both hooks.

Backend authorization is unchanged and still validates the caller's manager role
in whichever household the header names.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KhzQxE83PRcuaLJ7LAPbmo