### PR TITLE
Refresh shopping lists on app resume and SSE reconnect

### DIFF
--- a/anything-frontend/src/hooks/useRealtimeSync.test.tsx
+++ b/anything-frontend/src/hooks/useRealtimeSync.test.tsx
@@ -1,0 +1,193 @@
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useRealtimeSync } from "@/hooks/useRealtimeSync";
+
+jest.mock("@/hooks/useAuth", () => ({
+  getAccessToken: jest.fn(() => "test-token"),
+}));
+
+import { getAccessToken } from "@/hooks/useAuth";
+
+const mockedGetAccessToken = getAccessToken as jest.MockedFunction<
+  typeof getAccessToken
+>;
+
+// Minimal fake EventSource: captures handlers, tracks instances and readyState.
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  static readonly CLOSED = 2;
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  readyState = 0;
+  closed = false;
+  url: string;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+
+  emitOpen() {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+
+  emitMessage(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent<string>);
+  }
+
+  close() {
+    this.closed = true;
+    this.readyState = FakeEventSource.CLOSED;
+  }
+}
+
+function setOnline(value: boolean) {
+  Object.defineProperty(navigator, "onLine", { configurable: true, value });
+}
+
+function setHidden(value: boolean) {
+  Object.defineProperty(document, "hidden", { configurable: true, value });
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value: value ? "hidden" : "visible",
+  });
+}
+
+function renderRealtimeSync() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  const view = renderHook(() => useRealtimeSync(), { wrapper });
+  return { ...view, invalidateSpy };
+}
+
+describe("useRealtimeSync", () => {
+  const originalEventSource = global.EventSource;
+
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    mockedGetAccessToken.mockReturnValue("test-token");
+    setOnline(true);
+    setHidden(false);
+    (global as unknown as { EventSource: unknown }).EventSource =
+      FakeEventSource;
+  });
+
+  afterEach(() => {
+    (global as unknown as { EventSource: unknown }).EventSource =
+      originalEventSource;
+    jest.clearAllMocks();
+  });
+
+  it("does not connect when there is no access token", () => {
+    mockedGetAccessToken.mockReturnValue(null);
+    renderRealtimeSync();
+    expect(FakeEventSource.instances).toHaveLength(0);
+  });
+
+  it("invalidates the matching items key on a shoppingListItems message", () => {
+    const { invalidateSpy } = renderRealtimeSync();
+    const es = FakeEventSource.instances[0];
+
+    act(() => {
+      es.emitMessage({ type: "shoppingListItems", listId: 42 });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["shoppingListItems", 42],
+    });
+  });
+
+  it("does not invalidate on the first connection but does on reconnect", () => {
+    const { invalidateSpy } = renderRealtimeSync();
+    const es = FakeEventSource.instances[0];
+
+    act(() => {
+      es.emitOpen();
+    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      es.emitOpen();
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["shoppingLists"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["shoppingListItems"],
+    });
+  });
+
+  it("revalidates when the app becomes visible again while online", () => {
+    const { invalidateSpy } = renderRealtimeSync();
+
+    act(() => {
+      setHidden(false);
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["shoppingLists"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["shoppingListTemplates"],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["shoppingList"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["shoppingListItems"],
+    });
+  });
+
+  it("does not revalidate on resume while offline", () => {
+    const { invalidateSpy } = renderRealtimeSync();
+
+    act(() => {
+      setOnline(false);
+      setHidden(false);
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not revalidate when the visibilitychange leaves the document hidden", () => {
+    const { invalidateSpy } = renderRealtimeSync();
+
+    act(() => {
+      setHidden(true);
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("reconnects on resume when the connection was closed", () => {
+    renderRealtimeSync();
+    const first = FakeEventSource.instances[0];
+    first.close();
+
+    act(() => {
+      setHidden(false);
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(FakeEventSource.instances).toHaveLength(2);
+  });
+
+  it("closes the connection and removes listeners on unmount", () => {
+    const removeSpy = jest.spyOn(document, "removeEventListener");
+    const { unmount } = renderRealtimeSync();
+    const es = FakeEventSource.instances[0];
+
+    unmount();
+
+    expect(es.closed).toBe(true);
+    expect(removeSpy).toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.any(Function)
+    );
+  });
+});

--- a/anything-frontend/src/hooks/useRealtimeSync.ts
+++ b/anything-frontend/src/hooks/useRealtimeSync.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { getAccessToken } from "@/hooks/useAuth";
 
 type SyncEvent =
@@ -11,6 +11,23 @@ type SyncEvent =
 
 const SSE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5238";
 
+// Every shopping-list query key this hook keeps fresh. Invalidating these
+// refetches active observers regardless of staleTime, so the open list
+// revalidates immediately. Partial keys (e.g. ["shoppingListItems"]) match
+// every list id.
+const SHOPPING_QUERY_KEYS = [
+  ["shoppingLists"],
+  ["shoppingListTemplates"],
+  ["shoppingList"],
+  ["shoppingListItems"],
+] as const;
+
+function invalidateShoppingQueries(queryClient: QueryClient) {
+  for (const queryKey of SHOPPING_QUERY_KEYS) {
+    void queryClient.invalidateQueries({ queryKey });
+  }
+}
+
 export function useRealtimeSync() {
   const queryClient = useQueryClient();
 
@@ -19,27 +36,75 @@ export function useRealtimeSync() {
     if (!token) return;
 
     const url = `${SSE_URL}/api/events?token=${encodeURIComponent(token)}`;
-    const es = new EventSource(url);
+    let source: EventSource | null = null;
+    // The first onopen is the initial connection — the persister's onSuccess
+    // already invalidates the cache on a cold start, so skip it here to avoid a
+    // redundant refetch. Every later onopen is an auto-reconnect after a dropped
+    // connection, where we must catch events missed while disconnected.
+    let isFirstConnect = true;
 
-    es.onmessage = (event: MessageEvent<string>) => {
-      try {
-        const data = JSON.parse(event.data) as SyncEvent;
-        if (data.type === "shoppingLists") {
-          queryClient.invalidateQueries({ queryKey: ["shoppingLists"] });
-        } else if (data.type === "shoppingListTemplates") {
-          queryClient.invalidateQueries({ queryKey: ["shoppingListTemplates"] });
-        } else if (data.type === "shoppingListItems" && data.listId !== undefined) {
-          queryClient.invalidateQueries({
-            queryKey: ["shoppingListItems", data.listId],
-          });
+    const connect = () => {
+      const es = new EventSource(url);
+
+      es.onopen = () => {
+        if (isFirstConnect) {
+          isFirstConnect = false;
+          return;
         }
-      } catch {
-        // Malformed event — ignore
+        invalidateShoppingQueries(queryClient);
+      };
+
+      es.onmessage = (event: MessageEvent<string>) => {
+        try {
+          const data = JSON.parse(event.data) as SyncEvent;
+          if (data.type === "shoppingLists") {
+            void queryClient.invalidateQueries({ queryKey: ["shoppingLists"] });
+          } else if (data.type === "shoppingListTemplates") {
+            void queryClient.invalidateQueries({
+              queryKey: ["shoppingListTemplates"],
+            });
+          } else if (
+            data.type === "shoppingListItems" &&
+            data.listId !== undefined
+          ) {
+            void queryClient.invalidateQueries({
+              queryKey: ["shoppingListItems", data.listId],
+            });
+          }
+        } catch {
+          // Malformed event — ignore
+        }
+      };
+
+      source = es;
+    };
+
+    connect();
+
+    // Warm resume (PWA/tab brought back to the foreground) does not remount the
+    // app, so neither the cache restore nor a mount-time refetch fires. On
+    // becoming visible again, revalidate against the server so changes made by
+    // other users while the app was backgrounded appear without a manual
+    // refresh — and revive the SSE connection if it was dropped while hidden.
+    const handleResume = () => {
+      if (typeof document !== "undefined" && document.hidden) return;
+      if (navigator.onLine === false) return;
+
+      invalidateShoppingQueries(queryClient);
+
+      if (!source || source.readyState === EventSource.CLOSED) {
+        source?.close();
+        connect();
       }
     };
 
+    document.addEventListener("visibilitychange", handleResume);
+    window.addEventListener("focus", handleResume);
+
     return () => {
-      es.close();
+      document.removeEventListener("visibilitychange", handleResume);
+      window.removeEventListener("focus", handleResume);
+      source?.close();
     };
   }, [queryClient]);
 }


### PR DESCRIPTION
The SSE realtime channel only kept lists fresh while the app was open in
the foreground. If another user changed a list while the app was closed or
backgrounded, the change was missed: events broadcast during the
disconnect are not replayed, refetchOnWindowFocus is disabled, and a warm
resume does not remount to trigger the persister's cache-restore
invalidation. Returning to the app already on the list showed stale data
until a manual refresh.

useRealtimeSync now revalidates the shopping-list queries whenever the app
regains visibility/focus or the SSE connection re-establishes after a drop,
and revives a closed EventSource on resume. Invalidations are skipped while
offline and on the initial connection (the persister already invalidates on
cold start). Adds a unit test covering messages, reconnect, resume, offline,
and cleanup.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0194ePTzUotJnKHU95Weu6fz