### PR TITLE
Fix GroupBy count translation in search index overview query

### DIFF
--- a/src/Anything.Application/Features/Search/Queries/GetSearchIndexOverview.cs
+++ b/src/Anything.Application/Features/Search/Queries/GetSearchIndexOverview.cs
@@ -22,8 +22,8 @@ public class GetSearchIndexOverviewHandler(IRepository<SearchDocument> repositor
 
         var byType = await baseQuery
             .GroupBy(d => d.EntityType)
+            .OrderBy(g => g.Key)
             .Select(g => new SearchIndexTypeCount(g.Key, g.Count()))
-            .OrderBy(x => x.EntityType)
             .ToListAsync(ct);
 
         var lastIndexedOn = await baseQuery


### PR DESCRIPTION
Ordering by the projected SearchIndexTypeCount.EntityType after the
GroupBy/Select forced EF Core to treat the per-group Count() as an
uncorrelated subquery it couldn't translate. Ordering by the group key
before projecting keeps the aggregate translatable to SQL.