### PR TITLE
Fix inventory item detail crash on purchasedOn.toLocaleDateString

### DIFF
--- a/anything-frontend/src/app/inventory/items/[id]/page.tsx
+++ b/anything-frontend/src/app/inventory/items/[id]/page.tsx
@@ -38,8 +38,17 @@ function formatCurrency(amount: number): string {
   }).format(amount);
 }
 
-function formatDate(date: Date): string {
-  return date.toLocaleDateString("da-DK", { year: "numeric", month: "short", day: "numeric" });
+// `item.purchasedOn`/`warrantyExpiresOn` are typed as `Date` by the generated
+// client, but a query restored from the offline persister (see
+// lib/offline/persister.ts) has been through a JSON.stringify/parse round
+// trip, which turns Date instances back into plain ISO strings until the
+// post-restore refetch lands. Re-wrapping in `new Date()` here handles both.
+function formatDate(date: Date | string): string {
+  return new Date(date).toLocaleDateString("da-DK", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
 }
 
 export default function ItemDetailPage() {

--- a/anything-frontend/src/hooks/useInventory.test.tsx
+++ b/anything-frontend/src/hooks/useInventory.test.tsx
@@ -337,6 +337,24 @@ describe('useInventory hooks', () => {
       expect(mockItemById).toHaveBeenCalledWith(100)
     })
 
+    it('normalizes purchasedOn/warrantyExpiresOn back into Date objects even when the cache holds plain strings', async () => {
+      // Simulates data restored from the offline persister, which round-trips
+      // through JSON.stringify/parse and turns Date instances back into strings.
+      mockItemItemGet.mockResolvedValueOnce({
+        ...item,
+        purchasedOn: '2024-01-15T00:00:00Z',
+        warrantyExpiresOn: '2026-01-15T00:00:00Z',
+      })
+
+      const { result } = renderHook(() => useInventoryItem(100), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(result.current.data?.purchasedOn).toBeInstanceOf(Date)
+      expect(result.current.data?.warrantyExpiresOn).toBeInstanceOf(Date)
+    })
+
     it('creates an item, sending explicit nulls for the fields left blank', async () => {
       mockItemsPost.mockResolvedValueOnce(item)
 

--- a/anything-frontend/src/hooks/useInventory.ts
+++ b/anything-frontend/src/hooks/useInventory.ts
@@ -218,12 +218,30 @@ export function useInventoryItems() {
   });
 }
 
+/**
+ * `purchasedOn`/`warrantyExpiresOn` are typed as `Date` by the generated
+ * client, but a query restored from the offline persister (see
+ * lib/offline/persister.ts) has been through a JSON.stringify/parse round
+ * trip, which turns Date instances back into plain ISO strings until the
+ * post-restore refetch lands. `select` re-normalizes on every read (not just
+ * on fetch), so consumers always see a real Date regardless of where the
+ * cached value came from.
+ */
+function toDateOrNull(value: Date | string | null | undefined): Date | null {
+  return value ? new Date(value) : null;
+}
+
 export function useInventoryItem(id: number) {
   return useQuery({
     queryKey: [ITEM_KEY, id],
     enabled: id > 0,
     refetchOnMount: "always",
     queryFn: () => apiClient.api.inventoryItems.byId(id).get() as Promise<InventoryItemResponse>,
+    select: (item): InventoryItemResponse => ({
+      ...item,
+      purchasedOn: toDateOrNull(item.purchasedOn),
+      warrantyExpiresOn: toDateOrNull(item.warrantyExpiresOn),
+    }),
   });
 }
 


### PR DESCRIPTION
The offline query cache (lib/offline/persister.ts) round-trips through
JSON.stringify/parse on every app load, which turns the Kiota client's
Date-typed purchasedOn/warrantyExpiresOn fields back into plain strings
until the post-restore refetch lands. The item detail page rendered
that restored data with a formatDate() that called .toLocaleDateString
directly on item.purchasedOn without re-wrapping it in new Date(),
unlike every other date formatter in the app - so viewing an item with
those fields set crashed right after a reload.

Normalize both fields to real Date instances in useInventoryItem's
select (which runs on every cache read, not just on fetch) so
formatDate, WarrantyBadge, and ItemFormDialog's toDateInputValue all
see a real Date regardless of whether the data came from a fresh fetch
or a persisted cache restore.