### PR TITLE
Fix home preferences race that could revert the latest edit

### DIFF
--- a/anything-frontend/src/hooks/useHomePreferences.test.tsx
+++ b/anything-frontend/src/hooks/useHomePreferences.test.tsx
@@ -199,5 +199,69 @@ describe('useHomePreferences hooks', () => {
 
       expect(queryClient.getQueryData(['homeCardPreferences'])).toEqual(original)
     })
+
+    // Regression test: dragging to reorder and toggling a switch each fire their own
+    // mutation, and doing both in quick succession (before the first PUT settles) used to
+    // let the two requests race over the network. If the earlier request's response landed
+    // last, its onSuccess handler reasserted its own (now stale) snapshot over the cache,
+    // silently reverting the later edit — the home page would then show the wrong cards
+    // after navigating back, even though nothing had actually failed.
+    it('keeps the latest edit when two mutations are triggered before either settles', async () => {
+      const resolvers: Array<() => void> = []
+      mockPut.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolvers.push(resolve)
+          })
+      )
+
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+      })
+      queryClient.setQueryData(['homeCardPreferences'], [
+        { cardKey: 'foodplan', sortOrder: 0, isVisible: true },
+        { cardKey: 'lists', sortOrder: 1, isVisible: true },
+        { cardKey: 'bills', sortOrder: 2, isVisible: false },
+      ])
+      const Wrapper = ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+      Wrapper.displayName = 'TestQueryClientWrapper'
+
+      const { result } = renderHook(() => useUpdateHomeCardPreferences(), { wrapper: Wrapper })
+
+      // Toggle "lists" off (request A)...
+      await act(async () => {
+        result.current.mutate([
+          { cardKey: 'foodplan', isVisible: true },
+          { cardKey: 'lists', isVisible: false },
+          { cardKey: 'bills', isVisible: false },
+        ])
+      })
+
+      // ...then quickly toggle "bills" on (request B), before A's PUT resolves.
+      await act(async () => {
+        result.current.mutate([
+          { cardKey: 'foodplan', isVisible: true },
+          { cardKey: 'lists', isVisible: false },
+          { cardKey: 'bills', isVisible: true },
+        ])
+      })
+
+      // Scope-serialized mutations mean B's PUT does not start until A settles.
+      await waitFor(() => expect(resolvers.length).toBe(1))
+      await act(async () => resolvers[0]())
+
+      await waitFor(() => expect(resolvers.length).toBe(2))
+      await act(async () => resolvers[1]())
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(queryClient.getQueryData(['homeCardPreferences'])).toEqual([
+        { cardKey: 'foodplan', sortOrder: 0, isVisible: true },
+        { cardKey: 'lists', sortOrder: 1, isVisible: false },
+        { cardKey: 'bills', sortOrder: 2, isVisible: true },
+      ])
+    })
   })
 })

--- a/anything-frontend/src/hooks/useHomePreferences.ts
+++ b/anything-frontend/src/hooks/useHomePreferences.ts
@@ -28,6 +28,12 @@ export function useUpdateHomeCardPreferences() {
   const queryClient = useQueryClient();
 
   return useMutation({
+    // Toggling/reordering fires a mutation per action, and drag or rapid taps can start a
+    // second one before the first's PUT settles. A shared scope runs same-scope mutations
+    // in FIFO order (the next one waits for the previous to settle) instead of letting them
+    // race over the network, so an out-of-order response can no longer land last and have
+    // its onSuccess clobber the cache with a stale, already-superseded snapshot.
+    scope: { id: "homeCardPreferences" },
     mutationFn: (cards: { cardKey: string; isVisible: boolean }[]) =>
       apiClient.api.home.cardPreferences.put({ cards }),
     onMutate: async (cards) => {


### PR DESCRIPTION
Toggling a switch and dragging to reorder each fire their own mutation.
Doing two in quick succession (before the first PUT settles) let the
requests race over the network: if the earlier request's response
landed last, its onSuccess handler reasserted its own now-stale
snapshot over the shared homeCardPreferences cache, silently reverting
the later edit. Since the home page reads that same cache, it would
show the wrong cards after navigating back even though nothing failed.

Give the mutation a shared scope so same-scope mutations run in FIFO
order instead of racing, guaranteeing the last edit's response is
always the one applied last.