### PR TITLE
Downscale images before upload and unify the 10 MB size cap

### DIFF
--- a/anything-frontend/src/app/notes/import/page.test.tsx
+++ b/anything-frontend/src/app/notes/import/page.test.tsx
@@ -23,6 +23,7 @@ jest.mock("@/lib/apiClient", () => ({
     },
   },
   createMultipartBody: () => ({ addOrReplacePart: jest.fn() }),
+  buildFileUploadBody: async () => ({ addOrReplacePart: jest.fn() }),
 }));
 
 function pickFilesInput(): HTMLInputElement {

--- a/anything-frontend/src/app/recipes/[id]/RecipeEditMode.test.tsx
+++ b/anything-frontend/src/app/recipes/[id]/RecipeEditMode.test.tsx
@@ -39,6 +39,7 @@ jest.mock('@/lib/apiClient', () => ({
     },
   },
   createMultipartBody: () => ({ addOrReplacePart: jest.fn() }),
+  buildFileUploadBody: async () => ({ addOrReplacePart: jest.fn() }),
 }))
 
 jest.mock('@/hooks/useRecommendations', () => ({

--- a/anything-frontend/src/app/recipes/[id]/page.test.tsx
+++ b/anything-frontend/src/app/recipes/[id]/page.test.tsx
@@ -58,6 +58,7 @@ jest.mock('@/lib/apiClient', () => ({
     },
   },
   createMultipartBody: () => ({ addOrReplacePart: jest.fn() }),
+  buildFileUploadBody: async () => ({ addOrReplacePart: jest.fn() }),
 }))
 
 jest.mock('@/hooks/useRecommendations', () => ({

--- a/anything-frontend/src/components/inventory/AddPhotoMenu.tsx
+++ b/anything-frontend/src/components/inventory/AddPhotoMenu.tsx
@@ -47,8 +47,9 @@ export function AddPhotoMenu({ onUpload, isUploading, variant = "overlay" }: Add
         setProgress({ done: index, total: files.length });
         await onUpload({ file, kind: InventoryAttachmentKinds.Photo });
       }
-    } catch {
-      toast.error(files.length > 1 ? "Failed to upload every photo" : "Failed to upload photo");
+    } catch (err) {
+      const fallback = files.length > 1 ? "Failed to upload every photo" : "Failed to upload photo";
+      toast.error(err instanceof Error ? err.message : fallback);
     } finally {
       setProgress(null);
       // Cleared so re-picking the same file still fires `change`.

--- a/anything-frontend/src/components/inventory/InventoryDocuments.tsx
+++ b/anything-frontend/src/components/inventory/InventoryDocuments.tsx
@@ -69,8 +69,8 @@ export function InventoryDocuments({
     try {
       await onUpload({ file: pendingDocumentFile, kind: documentKind });
       closeDocumentDialog();
-    } catch {
-      toast.error("Failed to upload document");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to upload document");
     }
   }
 

--- a/anything-frontend/src/hooks/useBills.test.tsx
+++ b/anything-frontend/src/hooks/useBills.test.tsx
@@ -76,6 +76,7 @@ jest.mock('@/lib/apiClient', () => ({
     },
   },
   createMultipartBody: () => ({ addOrReplacePart: jest.fn() }),
+  buildFileUploadBody: async () => ({ addOrReplacePart: jest.fn() }),
 }))
 
 function createWrapper() {

--- a/anything-frontend/src/hooks/useBills.test.tsx
+++ b/anything-frontend/src/hooks/useBills.test.tsx
@@ -335,6 +335,31 @@ describe('useBills hooks', () => {
 
       await waitFor(() => expect(result.current.isError).toBe(true))
     })
+
+    it('rejects a file over the 10 MB limit without calling the API', async () => {
+      const bigFile = new File([new ArrayBuffer(11 * 1024 * 1024)], 'huge.pdf', { type: 'application/pdf' })
+      const { result } = renderHook(() => useUploadBillAttachment(), { wrapper: createWrapper() })
+
+      await act(async () => {
+        result.current.mutate({ billId: 1, file: bigFile })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect(result.current.error?.message).toContain('too large')
+      expect(mockAttachmentsPost).not.toHaveBeenCalled()
+    })
+
+    it('maps a 413 response to a friendly message', async () => {
+      mockAttachmentsPost.mockRejectedValueOnce({ responseStatusCode: 413, message: 'Payload Too Large' })
+      const { result } = renderHook(() => useUploadBillAttachment(), { wrapper: createWrapper() })
+
+      await act(async () => {
+        result.current.mutate({ billId: 1, file: new File(['content'], 'invoice.pdf', { type: 'application/pdf' }) })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+      expect(result.current.error?.message).toBe('File is too large. Please use a file under 10 MB.')
+    })
   })
 
   describe('useDeleteBillAttachment', () => {

--- a/anything-frontend/src/hooks/useBills.ts
+++ b/anything-frontend/src/hooks/useBills.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { apiClient, createMultipartBody } from "@/lib/apiClient";
+import { apiClient, buildFileUploadBody } from "@/lib/apiClient";
 import { UPLOAD_TOO_LARGE_MESSAGE, assertUploadSize, prepareImageForUpload } from "@/lib/images";
 import type { CreateBillRequest, UpdateBillRequest, AddBillPriceRequest, BillAttachmentResponse } from "@/lib/api-client/models/index";
 
@@ -261,15 +261,7 @@ export function useUploadBillAttachment() {
       const file = await prepareImageForUpload(data.file);
       assertUploadSize(file);
 
-      const buffer = await file.arrayBuffer();
-      const multipartBody = createMultipartBody();
-      multipartBody.addOrReplacePart(
-        "file",
-        file.type || "application/octet-stream",
-        buffer,
-        undefined,
-        file.name
-      );
+      const multipartBody = await buildFileUploadBody(file);
       try {
         await apiClient.api.bills.byId(data.billId).attachments.post(multipartBody, {
           queryParameters: { name: data.name },

--- a/anything-frontend/src/hooks/useBills.ts
+++ b/anything-frontend/src/hooks/useBills.ts
@@ -2,6 +2,7 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient, createMultipartBody } from "@/lib/apiClient";
+import { UPLOAD_TOO_LARGE_MESSAGE, assertUploadSize, prepareImageForUpload } from "@/lib/images";
 import type { CreateBillRequest, UpdateBillRequest, AddBillPriceRequest, BillAttachmentResponse } from "@/lib/api-client/models/index";
 
 // Re-export API model type so consumers can import it from this hook
@@ -257,21 +258,27 @@ export function useUploadBillAttachment() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (data: { billId: number; file: File; name?: string }) => {
-      const buffer = await data.file.arrayBuffer();
+      const file = await prepareImageForUpload(data.file);
+      assertUploadSize(file);
+
+      const buffer = await file.arrayBuffer();
       const multipartBody = createMultipartBody();
       multipartBody.addOrReplacePart(
         "file",
-        data.file.type || "application/octet-stream",
+        file.type || "application/octet-stream",
         buffer,
         undefined,
-        data.file.name
+        file.name
       );
       try {
         await apiClient.api.bills.byId(data.billId).attachments.post(multipartBody, {
           queryParameters: { name: data.name },
         });
       } catch (e) {
-        const kiota = e as { message?: string };
+        const kiota = e as { responseStatusCode?: number; message?: string };
+        if (kiota.responseStatusCode === 413) {
+          throw new Error(UPLOAD_TOO_LARGE_MESSAGE);
+        }
         throw new Error(kiota.message || "Failed to upload attachment");
       }
     },

--- a/anything-frontend/src/hooks/useInventory.test.tsx
+++ b/anything-frontend/src/hooks/useInventory.test.tsx
@@ -103,6 +103,11 @@ jest.mock('@/lib/apiClient', () => ({
     },
   },
   createMultipartBody: () => ({ addOrReplacePart: mockAddOrReplacePart }),
+  buildFileUploadBody: async (file: File) => {
+    const fileContent = await file.arrayBuffer()
+    mockAddOrReplacePart('file', file.type || 'application/octet-stream', fileContent, undefined, file.name)
+    return { addOrReplacePart: mockAddOrReplacePart }
+  },
 }))
 
 function createWrapper() {

--- a/anything-frontend/src/hooks/useInventory.ts
+++ b/anything-frontend/src/hooks/useInventory.ts
@@ -3,6 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { MultipartBody } from "@microsoft/kiota-abstractions";
 import { apiClient, createMultipartBody } from "@/lib/apiClient";
+import { UPLOAD_TOO_LARGE_MESSAGE, assertUploadSize, prepareImageForUpload } from "@/lib/images";
 import type {
   InventoryAttachmentResponse,
   InventoryBoxResponse,
@@ -318,8 +319,6 @@ export function useDeleteInventoryItem() {
 // identical (mirroring the backend's shared `InventoryAttachment` table), so
 // upload/download are written once here and reused for all three owners.
 
-const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
-
 interface AttachmentsRequestBuilder {
   get(): Promise<InventoryAttachmentResponse[] | undefined>;
   post(
@@ -336,22 +335,19 @@ async function uploadInventoryAttachment(
   builder: AttachmentsRequestBuilder,
   data: { file: File; kind?: string; name?: string }
 ): Promise<void> {
-  if (data.file.size > MAX_ATTACHMENT_SIZE_BYTES) {
-    throw new Error(
-      `File is too large (${(data.file.size / 1024 / 1024).toFixed(1)} MB). Maximum allowed size is 10 MB.`
-    );
-  }
+  const file = await prepareImageForUpload(data.file);
+  assertUploadSize(file);
 
   const multipartBody = createMultipartBody();
   // Kiota's multipart serializer only supports string/ArrayBuffer/Uint8Array
   // part content — passing the File object itself throws before any request.
-  const fileContent = await data.file.arrayBuffer();
+  const fileContent = await file.arrayBuffer();
   multipartBody.addOrReplacePart(
     "file",
-    data.file.type || "application/octet-stream",
+    file.type || "application/octet-stream",
     fileContent,
     undefined,
-    data.file.name
+    file.name
   );
 
   try {
@@ -359,7 +355,7 @@ async function uploadInventoryAttachment(
   } catch (e) {
     const kiota = e as { responseStatusCode?: number; message?: string };
     if (kiota.responseStatusCode === 413) {
-      throw new Error("File is too large. Please use a file under 10 MB.");
+      throw new Error(UPLOAD_TOO_LARGE_MESSAGE);
     }
     throw new Error(kiota.message || "Failed to upload attachment");
   }

--- a/anything-frontend/src/hooks/useInventory.ts
+++ b/anything-frontend/src/hooks/useInventory.ts
@@ -2,7 +2,7 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { MultipartBody } from "@microsoft/kiota-abstractions";
-import { apiClient, createMultipartBody } from "@/lib/apiClient";
+import { apiClient, buildFileUploadBody } from "@/lib/apiClient";
 import { UPLOAD_TOO_LARGE_MESSAGE, assertUploadSize, prepareImageForUpload } from "@/lib/images";
 import type {
   InventoryAttachmentResponse,
@@ -338,17 +338,7 @@ async function uploadInventoryAttachment(
   const file = await prepareImageForUpload(data.file);
   assertUploadSize(file);
 
-  const multipartBody = createMultipartBody();
-  // Kiota's multipart serializer only supports string/ArrayBuffer/Uint8Array
-  // part content — passing the File object itself throws before any request.
-  const fileContent = await file.arrayBuffer();
-  multipartBody.addOrReplacePart(
-    "file",
-    file.type || "application/octet-stream",
-    fileContent,
-    undefined,
-    file.name
-  );
+  const multipartBody = await buildFileUploadBody(file);
 
   try {
     await builder.post(multipartBody, { queryParameters: { kind: data.kind, name: data.name } });

--- a/anything-frontend/src/hooks/useNotes.test.tsx
+++ b/anything-frontend/src/hooks/useNotes.test.tsx
@@ -14,6 +14,7 @@ jest.mock("@/lib/apiClient", () => ({
     },
   },
   createMultipartBody: () => ({ addOrReplacePart: jest.fn() }),
+  buildFileUploadBody: async () => ({ addOrReplacePart: jest.fn() }),
 }));
 
 function createWrapper() {

--- a/anything-frontend/src/hooks/useNotes.ts
+++ b/anything-frontend/src/hooks/useNotes.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { apiClient, createMultipartBody } from "@/lib/apiClient";
+import { apiClient, buildFileUploadBody } from "@/lib/apiClient";
 import { UPLOAD_TOO_LARGE_MESSAGE, assertUploadSize, prepareImageForUpload } from "@/lib/images";
 import type { NoteResponse, NoteSummaryResponse } from "@/lib/api-client/models/index";
 
@@ -83,17 +83,7 @@ export function useUploadNoteImage() {
       const file = await prepareImageForUpload(imageFile);
       assertUploadSize(file);
 
-      const multipartBody = createMultipartBody();
-      // Kiota's multipart serializer only supports string/ArrayBuffer/Uint8Array
-      // part content — passing the File object itself throws before any request.
-      const fileContent = await file.arrayBuffer();
-      multipartBody.addOrReplacePart(
-        "file",
-        file.type || "application/octet-stream",
-        fileContent,
-        undefined,
-        file.name
-      );
+      const multipartBody = await buildFileUploadBody(file);
 
       try {
         const image = await apiClient.api.notes.images.post(multipartBody);

--- a/anything-frontend/src/hooks/useNotes.ts
+++ b/anything-frontend/src/hooks/useNotes.ts
@@ -2,6 +2,7 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient, createMultipartBody } from "@/lib/apiClient";
+import { UPLOAD_TOO_LARGE_MESSAGE, assertUploadSize, prepareImageForUpload } from "@/lib/images";
 import type { NoteResponse, NoteSummaryResponse } from "@/lib/api-client/models/index";
 
 export type { NoteResponse, NoteSummaryResponse };
@@ -71,8 +72,6 @@ export function useUpdateNote() {
   });
 }
 
-const MAX_NOTE_IMAGE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB — matches the API's Kestrel/form body limit.
-
 /**
  * Uploads an image for a note body and returns where it lives — a note id
  * isn't required (see the backend's `UploadNoteImageHandler`), so this can run
@@ -80,12 +79,9 @@ const MAX_NOTE_IMAGE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB — matches the API
  */
 export function useUploadNoteImage() {
   return useMutation({
-    mutationFn: async (file: File): Promise<UploadedNoteImage> => {
-      if (file.size > MAX_NOTE_IMAGE_SIZE_BYTES) {
-        throw new Error(
-          `File is too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Maximum allowed size is 10 MB.`
-        );
-      }
+    mutationFn: async (imageFile: File): Promise<UploadedNoteImage> => {
+      const file = await prepareImageForUpload(imageFile);
+      assertUploadSize(file);
 
       const multipartBody = createMultipartBody();
       // Kiota's multipart serializer only supports string/ArrayBuffer/Uint8Array
@@ -108,7 +104,7 @@ export function useUploadNoteImage() {
       } catch (e) {
         const kiota = e as { responseStatusCode?: number; message?: string };
         if (kiota.responseStatusCode === 413) {
-          throw new Error("File is too large. Please use a file under 10 MB.");
+          throw new Error(UPLOAD_TOO_LARGE_MESSAGE);
         }
         throw new Error(kiota.message || "Failed to upload image");
       }

--- a/anything-frontend/src/hooks/useRecipes.test.tsx
+++ b/anything-frontend/src/hooks/useRecipes.test.tsx
@@ -102,6 +102,7 @@ jest.mock('@/lib/apiClient', () => ({
     },
   },
   createMultipartBody: () => mockMultipartBodyInstance,
+  buildFileUploadBody: async () => mockMultipartBodyInstance,
   HOUSEHOLD_ID_KEY: 'householdId',
   HOUSEHOLD_HEADER: 'X-Household-Id',
 }))

--- a/anything-frontend/src/hooks/useRecipes.ts
+++ b/anything-frontend/src/hooks/useRecipes.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { apiClient, createMultipartBody } from "@/lib/apiClient";
+import { apiClient, buildFileUploadBody } from "@/lib/apiClient";
 import { UPLOAD_TOO_LARGE_MESSAGE, assertUploadSize, prepareImageForUpload } from "@/lib/images";
 import type {
   Recipe,
@@ -467,17 +467,7 @@ export async function uploadRecipeImageFile(recipeId: number, imageFile: File): 
   const file = await prepareImageForUpload(imageFile);
   assertUploadSize(file);
 
-  const multipartBody = createMultipartBody();
-  // Kiota's multipart serializer only supports string/ArrayBuffer/Uint8Array
-  // part content — passing the File object itself throws before any request.
-  const fileContent = await file.arrayBuffer();
-  multipartBody.addOrReplacePart(
-    "file",
-    file.type || "application/octet-stream",
-    fileContent,
-    undefined,
-    file.name
-  );
+  const multipartBody = await buildFileUploadBody(file);
 
   try {
     await apiClient.api.recipes.byId(recipeId).images.upload.post(multipartBody);

--- a/anything-frontend/src/hooks/useRecipes.ts
+++ b/anything-frontend/src/hooks/useRecipes.ts
@@ -2,6 +2,7 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient, createMultipartBody } from "@/lib/apiClient";
+import { UPLOAD_TOO_LARGE_MESSAGE, assertUploadSize, prepareImageForUpload } from "@/lib/images";
 import type {
   Recipe,
   RecipeListItemResponse,
@@ -462,14 +463,9 @@ export function useImportRecipe() {
   });
 }
 
-const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
-
-export async function uploadRecipeImageFile(recipeId: number, file: File): Promise<void> {
-  if (file.size > MAX_IMAGE_SIZE_BYTES) {
-    throw new Error(
-      `File is too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Maximum allowed size is 10 MB.`
-    );
-  }
+export async function uploadRecipeImageFile(recipeId: number, imageFile: File): Promise<void> {
+  const file = await prepareImageForUpload(imageFile);
+  assertUploadSize(file);
 
   const multipartBody = createMultipartBody();
   // Kiota's multipart serializer only supports string/ArrayBuffer/Uint8Array
@@ -488,7 +484,7 @@ export async function uploadRecipeImageFile(recipeId: number, file: File): Promi
   } catch (e) {
     const kiota = e as { responseStatusCode?: number };
     if (kiota.responseStatusCode === 413) {
-      throw new Error("File is too large. Please use an image under 10 MB.");
+      throw new Error(UPLOAD_TOO_LARGE_MESSAGE);
     }
     if (kiota.responseStatusCode === 401 || kiota.responseStatusCode === 403) {
       throw new Error("You are not authorised to upload images.");

--- a/anything-frontend/src/lib/apiClient.ts
+++ b/anything-frontend/src/lib/apiClient.ts
@@ -188,3 +188,22 @@ export const apiClient = createApiClient(adapter);
 export function createMultipartBody(): MultipartBody {
   return new MultipartBody();
 }
+
+/**
+ * Builds the single-file multipart body every upload mutation sends under the
+ * part name "file". Kiota's multipart serializer only supports
+ * string/ArrayBuffer/Uint8Array part content — passing the File object itself
+ * throws before any request, so the file is read into an ArrayBuffer first.
+ */
+export async function buildFileUploadBody(file: File): Promise<MultipartBody> {
+  const multipartBody = createMultipartBody();
+  const fileContent = await file.arrayBuffer();
+  multipartBody.addOrReplacePart(
+    "file",
+    file.type || "application/octet-stream",
+    fileContent,
+    undefined,
+    file.name
+  );
+  return multipartBody;
+}

--- a/anything-frontend/src/lib/images.test.ts
+++ b/anything-frontend/src/lib/images.test.ts
@@ -1,4 +1,10 @@
-import { downscaleImage } from "./images";
+import {
+  MAX_UPLOAD_BYTES,
+  assertUploadSize,
+  downscaleImage,
+  isResizableImage,
+  prepareImageForUpload,
+} from "./images";
 
 describe("downscaleImage", () => {
   it("falls back to the original file when the image cannot be decoded", async () => {
@@ -6,5 +12,56 @@ describe("downscaleImage", () => {
 
     // jsdom has no createImageBitmap, so decoding fails and the file is returned.
     await expect(downscaleImage(file)).resolves.toBe(file);
+  });
+});
+
+describe("isResizableImage", () => {
+  it.each([
+    ["image/jpeg", true],
+    ["image/png", true],
+    ["image/webp", true],
+    ["image/gif", false],
+    ["image/svg+xml", false],
+    ["application/pdf", false],
+    ["", false],
+  ])("returns %s for %s", (type, expected) => {
+    const file = new File(["data"], "file", { type });
+    expect(isResizableImage(file)).toBe(expected);
+  });
+});
+
+describe("prepareImageForUpload", () => {
+  it("passes non-image files through untouched", async () => {
+    const file = new File(["%PDF-1.4"], "manual.pdf", { type: "application/pdf" });
+    await expect(prepareImageForUpload(file)).resolves.toBe(file);
+  });
+
+  it("passes GIFs through untouched to preserve animation", async () => {
+    const file = new File(["GIF89a"], "photo.gif", { type: "image/gif" });
+    await expect(prepareImageForUpload(file)).resolves.toBe(file);
+  });
+
+  it("passes SVGs through untouched", async () => {
+    const file = new File(["<svg/>"], "icon.svg", { type: "image/svg+xml" });
+    await expect(prepareImageForUpload(file)).resolves.toBe(file);
+  });
+
+  it("returns the original file when it cannot be decoded (jsdom has no createImageBitmap)", async () => {
+    const file = new File(["not an image"], "photo.jpg", { type: "image/jpeg" });
+    await expect(prepareImageForUpload(file)).resolves.toBe(file);
+  });
+});
+
+describe("assertUploadSize", () => {
+  it("does not throw for a file at or under the cap", () => {
+    const file = new File([new Uint8Array(MAX_UPLOAD_BYTES)], "photo.jpg", { type: "image/jpeg" });
+    expect(() => assertUploadSize(file)).not.toThrow();
+  });
+
+  it("throws with the file's actual size when it exceeds the cap", () => {
+    const file = new File([new Uint8Array(MAX_UPLOAD_BYTES + 1024 * 1024)], "photo.jpg", {
+      type: "image/jpeg",
+    });
+    expect(() => assertUploadSize(file)).toThrow(/File is too large \(11\.0 MB\)/);
   });
 });

--- a/anything-frontend/src/lib/images.ts
+++ b/anything-frontend/src/lib/images.ts
@@ -1,15 +1,32 @@
 /**
  * Client-side image helpers shared by every feature that lets a user attach a
- * photo (recipe OCR scans, note images): downscaling before upload.
+ * photo (inventory/bill attachments, recipe images, note images, OCR scans):
+ * downscaling and size-capping before upload.
  */
 
-const MAX_IMAGE_DIMENSION = 2000;
+const MAX_IMAGE_DIMENSION = 1920;
+const UPLOAD_IMAGE_QUALITY = 0.85;
+
+// Re-encode even an already-small-dimension image once it gets this heavy
+// (e.g. an unoptimized screenshot or PNG) — dimensions alone don't catch that.
+const REENCODE_BYTE_THRESHOLD = 2 * 1024 * 1024;
+
+async function encodeAtScale(bitmap: ImageBitmap, scale: number): Promise<Blob | null> {
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.round(bitmap.width * scale);
+  canvas.height = Math.round(bitmap.height * scale);
+  const context = canvas.getContext("2d");
+  if (!context) return null;
+  context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+  return new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/jpeg", UPLOAD_IMAGE_QUALITY));
+}
 
 /**
- * Downscale a photo so its longest side is at most `maxDim` pixels. Phone
- * photos are often 4000px+, which is slower to upload/process and no more
- * useful than a smaller copy. Falls back to the original file if the image
- * cannot be decoded.
+ * Downscale a photo so its longest side is at most `maxDim` pixels, re-encoding
+ * as JPEG even when no resize is needed if the file is still unreasonably
+ * heavy for its dimensions. Phone photos are often 4000px+, which is slower to
+ * upload/process and no more useful than a smaller copy. Falls back to the
+ * original file if the image cannot be decoded.
  */
 export async function downscaleImage(file: File, maxDim: number = MAX_IMAGE_DIMENSION): Promise<Blob> {
   let bitmap: ImageBitmap;
@@ -21,20 +38,56 @@ export async function downscaleImage(file: File, maxDim: number = MAX_IMAGE_DIME
 
   try {
     const scale = maxDim / Math.max(bitmap.width, bitmap.height);
-    if (scale >= 1) return file;
+    if (scale >= 1 && file.size <= REENCODE_BYTE_THRESHOLD) return file;
 
-    const canvas = document.createElement("canvas");
-    canvas.width = Math.round(bitmap.width * scale);
-    canvas.height = Math.round(bitmap.height * scale);
-    const context = canvas.getContext("2d");
-    if (!context) return file;
-    context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
-
-    const blob = await new Promise<Blob | null>((resolve) =>
-      canvas.toBlob(resolve, "image/jpeg", 0.92)
-    );
+    const blob = await encodeAtScale(bitmap, Math.min(scale, 1));
     return blob ?? file;
   } finally {
     bitmap.close();
+  }
+}
+
+const NON_RESIZABLE_IMAGE_TYPES = new Set(["image/gif", "image/svg+xml"]);
+
+/**
+ * Whether a file is a raster image `downscaleImage` can safely re-encode.
+ * Excludes GIF (canvas would flatten animation to a single frame) and SVG
+ * (vector; re-encoding to JPEG is lossy and pointless).
+ */
+export function isResizableImage(file: File): boolean {
+  const mediaType = file.type.split(";")[0]?.trim().toLowerCase() ?? "";
+  return mediaType.startsWith("image/") && !NON_RESIZABLE_IMAGE_TYPES.has(mediaType);
+}
+
+/**
+ * Shrinks an image file before upload so a full-resolution phone photo isn't
+ * stored forever server-side when nothing in the app ever renders it larger
+ * than `MAX_IMAGE_DIMENSION`. Non-images, GIFs and SVGs pass through untouched
+ * (see `isResizableImage`); anything else is returned as a `File` (not a bare
+ * `Blob`) so callers can keep reading `.name`/`.type` for the multipart part.
+ */
+export async function prepareImageForUpload(file: File): Promise<File> {
+  if (!isResizableImage(file)) return file;
+
+  const blob = await downscaleImage(file);
+  if (blob === file) return file;
+
+  const jpegName = `${file.name.replace(/\.[^./]+$/, "")}.jpg`;
+  return new File([blob], jpegName, { type: "image/jpeg" });
+}
+
+// 10 MB — matches the API's Kestrel/form body limit (see UploadLimits.cs).
+export const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+const MAX_UPLOAD_MB = MAX_UPLOAD_BYTES / (1024 * 1024);
+
+/** Generic fallback for a server-side 413 (the request never reached the size check below). */
+export const UPLOAD_TOO_LARGE_MESSAGE = `File is too large. Please use a file under ${MAX_UPLOAD_MB} MB.`;
+
+/** Throws with the file's actual size when it exceeds the shared upload cap. */
+export function assertUploadSize(file: File): void {
+  if (file.size > MAX_UPLOAD_BYTES) {
+    throw new Error(
+      `File is too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Maximum allowed size is ${MAX_UPLOAD_MB} MB.`
+    );
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -13,8 +13,10 @@ http {
         server 127.0.0.1:3000;
     }
 
-    # Allow file uploads up to 10 MB (default is 1 MB)
-    client_max_body_size 10m;
+    # Transport-layer headroom over UploadLimits.MaxFileSizeBytes (10 MB) — see
+    # src/Anything.Core/Upload/UploadLimits.cs for why. Keep in sync with
+    # UploadLimits.MaxRequestBodyBytes and Program.cs's Kestrel config.
+    client_max_body_size 12m;
 
     server {
         listen 80;

--- a/src/Anything.API/Endpoints/BillEndpoints.cs
+++ b/src/Anything.API/Endpoints/BillEndpoints.cs
@@ -122,9 +122,9 @@ public static class BillEndpoints
 
         group.MapPost("/{id}/attachments", async (int id, IFormFile? file, string? name, IMediator mediator) =>
         {
-            if (file is null || file.Length == 0)
-                return Results.BadRequest("No file uploaded or file is empty.");
-            await using var stream = file.OpenReadStream();
+            if (UploadEndpointValidation.ValidateFile(file) is { } fileError)
+                return fileError;
+            await using var stream = file!.OpenReadStream();
             return await mediator.Send(new UploadBillAttachmentCommand(
                 id, stream, file.FileName, file.ContentType, file.Length, name));
         })

--- a/src/Anything.API/Endpoints/InventoryBoxEndpoints.cs
+++ b/src/Anything.API/Endpoints/InventoryBoxEndpoints.cs
@@ -76,9 +76,9 @@ public static class InventoryBoxEndpoints
 
         group.MapPost("/{id}/attachments", async (int id, IFormFile? file, string? kind, string? name, IMediator mediator) =>
         {
-            if (file is null || file.Length == 0)
-                return Results.BadRequest("No file uploaded or file is empty.");
-            await using var stream = file.OpenReadStream();
+            if (UploadEndpointValidation.ValidateFile(file) is { } fileError)
+                return fileError;
+            await using var stream = file!.OpenReadStream();
             return await mediator.Send(new UploadInventoryBoxAttachmentCommand(
                 id, stream, file.FileName, file.ContentType, file.Length, kind, name));
         })

--- a/src/Anything.API/Endpoints/InventoryItemEndpoints.cs
+++ b/src/Anything.API/Endpoints/InventoryItemEndpoints.cs
@@ -92,9 +92,9 @@ public static class InventoryItemEndpoints
 
         group.MapPost("/{id}/attachments", async (int id, IFormFile? file, string? kind, string? name, IMediator mediator) =>
         {
-            if (file is null || file.Length == 0)
-                return Results.BadRequest("No file uploaded or file is empty.");
-            await using var stream = file.OpenReadStream();
+            if (UploadEndpointValidation.ValidateFile(file) is { } fileError)
+                return fileError;
+            await using var stream = file!.OpenReadStream();
             return await mediator.Send(new UploadInventoryItemAttachmentCommand(
                 id, stream, file.FileName, file.ContentType, file.Length, kind, name));
         })

--- a/src/Anything.API/Endpoints/InventoryStorageUnitEndpoints.cs
+++ b/src/Anything.API/Endpoints/InventoryStorageUnitEndpoints.cs
@@ -74,9 +74,9 @@ public static class InventoryStorageUnitEndpoints
 
         group.MapPost("/{id}/attachments", async (int id, IFormFile? file, string? kind, string? name, IMediator mediator) =>
         {
-            if (file is null || file.Length == 0)
-                return Results.BadRequest("No file uploaded or file is empty.");
-            await using var stream = file.OpenReadStream();
+            if (UploadEndpointValidation.ValidateFile(file) is { } fileError)
+                return fileError;
+            await using var stream = file!.OpenReadStream();
             return await mediator.Send(new UploadInventoryStorageUnitAttachmentCommand(
                 id, stream, file.FileName, file.ContentType, file.Length, kind, name));
         })

--- a/src/Anything.API/Endpoints/NoteEndpoints.cs
+++ b/src/Anything.API/Endpoints/NoteEndpoints.cs
@@ -52,9 +52,9 @@ public static class NoteEndpoints
         // belongs to has been created (see UploadNoteImageHandler).
         group.MapPost("/images", async (IFormFile? file, IMediator mediator) =>
         {
-            if (file is null || file.Length == 0)
-                return Results.BadRequest("No file uploaded or file is empty.");
-            await using var stream = file.OpenReadStream();
+            if (UploadEndpointValidation.ValidateFile(file) is { } fileError)
+                return fileError;
+            await using var stream = file!.OpenReadStream();
             return await mediator.Send(new UploadNoteImageCommand(
                 stream, file.FileName, file.ContentType, file.Length));
         })

--- a/src/Anything.API/Endpoints/RecipeEndpoints.cs
+++ b/src/Anything.API/Endpoints/RecipeEndpoints.cs
@@ -314,9 +314,9 @@ public static class RecipeEndpoints
 
         group.MapPost("/{id}/images/upload", async (int id, IFormFile? file, IMediator mediator) =>
         {
-            if (file == null || file.Length == 0)
-                return Results.BadRequest("No file uploaded or file is empty.");
-            await using var stream = file.OpenReadStream();
+            if (UploadEndpointValidation.ValidateFile(file) is { } fileError)
+                return fileError;
+            await using var stream = file!.OpenReadStream();
             return await mediator.Send(new UploadRecipeImageCommand(id, stream, file.FileName, file.ContentType, file.Length));
         })
         .WithName("UploadRecipeImage")

--- a/src/Anything.API/Endpoints/UploadEndpointValidation.cs
+++ b/src/Anything.API/Endpoints/UploadEndpointValidation.cs
@@ -1,0 +1,16 @@
+using Anything.Core.Upload;
+
+namespace Anything.API.Endpoints;
+
+/// <summary>
+/// Shared "was a file actually sent" guard for the six multipart upload
+/// endpoints, run before an <see cref="IFormFile"/> is unwrapped into the
+/// stream/metadata primitives each Upload*Command expects.
+/// </summary>
+internal static class UploadEndpointValidation
+{
+    public static IResult? ValidateFile(IFormFile? file) =>
+        file is null || file.Length == 0
+            ? Results.BadRequest(UploadLimits.EmptyFileMessage)
+            : null;
+}

--- a/src/Anything.API/Program.cs
+++ b/src/Anything.API/Program.cs
@@ -4,6 +4,7 @@ using Anything.Application.Configuration;
 using Anything.Core.Constants;
 using Anything.Core.Entities;
 using Anything.Core.Services;
+using Anything.Core.Upload;
 using Anything.Database;
 using Anything.API;
 using Anything.API.Endpoints;
@@ -72,14 +73,15 @@ builder.Services.AddAuthorization(options =>
     options.AddPolicy(UserRoles.Admin, policy => policy.RequireRole(UserRoles.Admin));
 });
 
-// Allow large file uploads (up to 10 MB)
+// Transport-layer headroom over UploadLimits.MaxFileSizeBytes — see its
+// remarks for why the two are deliberately different sizes.
 builder.WebHost.ConfigureKestrel(serverOptions =>
 {
-    serverOptions.Limits.MaxRequestBodySize = 10 * 1024 * 1024; // 10 MB
+    serverOptions.Limits.MaxRequestBodySize = UploadLimits.MaxRequestBodyBytes;
 });
 builder.Services.Configure<Microsoft.AspNetCore.Http.Features.FormOptions>(options =>
 {
-    options.MultipartBodyLengthLimit = 10 * 1024 * 1024; // 10 MB
+    options.MultipartBodyLengthLimit = UploadLimits.MaxRequestBodyBytes;
 });
 
 // Add OpenAPI/Swagger

--- a/src/Anything.Application/Common/UploadValidation.cs
+++ b/src/Anything.Application/Common/UploadValidation.cs
@@ -1,0 +1,30 @@
+using Anything.Core.Upload;
+using Microsoft.AspNetCore.Http;
+
+namespace Anything.Application.Common;
+
+/// <summary>
+/// Shared empty-file/oversized-file validation for every upload handler
+/// (inventory/bill attachments, recipe and note images). <see cref="UploadLimits"/>
+/// lives in <c>Anything.Core</c>, which has no dependencies and so cannot
+/// return an <see cref="IResult"/> itself — this is the one place that turns
+/// its limits into the response each handler returns.
+/// </summary>
+public static class UploadValidation
+{
+    /// <summary>
+    /// Validates an upload's declared content length, returning the
+    /// <see cref="IResult"/> a handler should return immediately, or
+    /// <c>null</c> when the length is acceptable and the handler should proceed.
+    /// </summary>
+    public static IResult? ValidateFileSize(long contentLength)
+    {
+        if (contentLength == 0)
+            return Results.BadRequest(UploadLimits.EmptyFileMessage);
+
+        if (UploadLimits.ExceedsMaxFileSize(contentLength))
+            return Results.BadRequest(UploadLimits.FileTooLargeMessage);
+
+        return null;
+    }
+}

--- a/src/Anything.Application/Features/Bills/Commands/UploadBillAttachmentCommand.cs
+++ b/src/Anything.Application/Features/Bills/Commands/UploadBillAttachmentCommand.cs
@@ -1,7 +1,7 @@
+using Anything.Application.Common;
 using Anything.Core.Entities;
 using Anything.Core.Repositories;
 using Anything.Core.Services;
-using Anything.Core.Upload;
 using Anything.Mediator;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -25,7 +25,6 @@ public class UploadBillAttachmentHandler(
     TimeProvider timeProvider) : IRequestHandler<UploadBillAttachmentCommand, IResult>
 {
     private const string BillNotFound = "Bill not found.";
-    private const string InvalidFile = "No file uploaded or file is empty.";
 
     public async Task<IResult> Handle(UploadBillAttachmentCommand command, CancellationToken ct = default)
     {
@@ -35,11 +34,8 @@ public class UploadBillAttachmentHandler(
         if (bill is null)
             return Results.NotFound(BillNotFound);
 
-        if (command.ContentLength == 0)
-            return Results.BadRequest(InvalidFile);
-
-        if (UploadLimits.ExceedsMaxFileSize(command.ContentLength))
-            return Results.BadRequest(UploadLimits.FileTooLargeMessage);
+        if (UploadValidation.ValidateFileSize(command.ContentLength) is { } sizeError)
+            return sizeError;
 
         var storageKey = await imageStorageService.Upload(
             command.FileStream,

--- a/src/Anything.Application/Features/Bills/Commands/UploadBillAttachmentCommand.cs
+++ b/src/Anything.Application/Features/Bills/Commands/UploadBillAttachmentCommand.cs
@@ -1,6 +1,7 @@
 using Anything.Core.Entities;
 using Anything.Core.Repositories;
 using Anything.Core.Services;
+using Anything.Core.Upload;
 using Anything.Mediator;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -36,6 +37,9 @@ public class UploadBillAttachmentHandler(
 
         if (command.ContentLength == 0)
             return Results.BadRequest(InvalidFile);
+
+        if (UploadLimits.ExceedsMaxFileSize(command.ContentLength))
+            return Results.BadRequest(UploadLimits.FileTooLargeMessage);
 
         var storageKey = await imageStorageService.Upload(
             command.FileStream,

--- a/src/Anything.Application/Features/Inventory/Commands/UploadInventoryBoxAttachment.cs
+++ b/src/Anything.Application/Features/Inventory/Commands/UploadInventoryBoxAttachment.cs
@@ -3,6 +3,7 @@ using Anything.Core.Constants;
 using Anything.Core.Entities;
 using Anything.Core.Repositories;
 using Anything.Core.Services;
+using Anything.Core.Upload;
 using Anything.Mediator;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -39,6 +40,9 @@ public class UploadInventoryBoxAttachmentHandler(
 
         if (command.ContentLength == 0)
             return Results.BadRequest(InvalidFile);
+
+        if (UploadLimits.ExceedsMaxFileSize(command.ContentLength))
+            return Results.BadRequest(UploadLimits.FileTooLargeMessage);
 
         var kind = string.IsNullOrWhiteSpace(command.Kind) ? InventoryAttachmentKinds.Other : command.Kind;
         if (!InventoryAttachmentKinds.All.Contains(kind))

--- a/src/Anything.Application/Features/Inventory/Commands/UploadInventoryBoxAttachment.cs
+++ b/src/Anything.Application/Features/Inventory/Commands/UploadInventoryBoxAttachment.cs
@@ -1,9 +1,9 @@
+using Anything.Application.Common;
 using Anything.Application.Features.Inventory;
 using Anything.Core.Constants;
 using Anything.Core.Entities;
 using Anything.Core.Repositories;
 using Anything.Core.Services;
-using Anything.Core.Upload;
 using Anything.Mediator;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -28,7 +28,6 @@ public class UploadInventoryBoxAttachmentHandler(
     TimeProvider timeProvider) : IRequestHandler<UploadInventoryBoxAttachmentCommand, IResult>
 {
     private const string BoxNotFound = "Box not found.";
-    private const string InvalidFile = "No file uploaded or file is empty.";
     private const string InvalidKind = "Invalid attachment kind.";
 
     public async Task<IResult> Handle(UploadInventoryBoxAttachmentCommand command, CancellationToken ct = default)
@@ -38,11 +37,8 @@ public class UploadInventoryBoxAttachmentHandler(
         if (!boxExists)
             return Results.NotFound(BoxNotFound);
 
-        if (command.ContentLength == 0)
-            return Results.BadRequest(InvalidFile);
-
-        if (UploadLimits.ExceedsMaxFileSize(command.ContentLength))
-            return Results.BadRequest(UploadLimits.FileTooLargeMessage);
+        if (UploadValidation.ValidateFileSize(command.ContentLength) is { } sizeError)
+            return sizeError;
 
         var kind = string.IsNullOrWhiteSpace(command.Kind) ? InventoryAttachmentKinds.Other : command.Kind;
         if (!InventoryAttachmentKinds.All.Contains(kind))

--- a/src/Anything.Application/Features/Inventory/Commands/UploadInventoryItemAttachment.cs
+++ b/src/Anything.Application/Features/Inventory/Commands/UploadInventoryItemAttachment.cs
@@ -3,6 +3,7 @@ using Anything.Core.Constants;
 using Anything.Core.Entities;
 using Anything.Core.Repositories;
 using Anything.Core.Services;
+using Anything.Core.Upload;
 using Anything.Mediator;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -39,6 +40,9 @@ public class UploadInventoryItemAttachmentHandler(
 
         if (command.ContentLength == 0)
             return Results.BadRequest(InvalidFile);
+
+        if (UploadLimits.ExceedsMaxFileSize(command.ContentLength))
+            return Results.BadRequest(UploadLimits.FileTooLargeMessage);
 
         var kind = string.IsNullOrWhiteSpace(command.Kind) ? InventoryAttachmentKinds.Other : command.Kind;
         if (!InventoryAttachmentKinds.All.Contains(kind))

--- a/src/Anything.Application/Features/Inventory/Commands/UploadInventoryItemAttachment.cs
+++ b/src/Anything.Application/Features/Inventory/Commands/UploadInventoryItemAttachment.cs
@@ -1,9 +1,9 @@
+using Anything.Application.Common;
 using Anything.Application.Features.Inventory;
 using Anything.Core.Constants;
 using Anything.Core.Entities;
 using Anything.Core.Repositories;
 using Anything.Core.Services;
-using Anything.Core.Upload;
 using Anything.Mediator;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -28,7 +28,6 @@ public class UploadInventoryItemAttachmentHandler(
     TimeProvider timeProvider) : IRequestHandler<UploadInventoryItemAttachmentCommand, IResult>
 {
     private const string ItemNotFound = "Item not found.";
-    private const string InvalidFile = "No file uploaded or file is empty.";
     private const string InvalidKind = "Invalid attachment kind.";
 
     public async Task<IResult> Handle(UploadInventoryItemAttachmentCommand command, CancellationToken ct = default)
@@ -38,11 +37,8 @@ public class UploadInventoryItemAttachmentHandler(
         if (!itemExists)
             return Results.NotFound(ItemNotFound);
 
-        if (command.ContentLength == 0)
-            return Results.BadRequest(InvalidFile);
-
-        if (UploadLimits.ExceedsMaxFileSize(command.ContentLength))
-            return Results.BadRequest(UploadLimits.FileTooLargeMessage);
+        if (UploadValidation.ValidateFileSize(command.ContentLength) is { } sizeError)
+            return sizeError;
 
         var kind = string.IsNullOrWhiteSpace(command.Kind) ? InventoryAttachmentKinds.Other : command.Kind;
         if (!InventoryAttachmentKinds.All.Contains(kind))

--- a/src/Anything.Application/Features/Inventory/Commands/UploadInventoryStorageUnitAttachment.cs
+++ b/src/Anything.Application/Features/Inventory/Commands/UploadInventoryStorageUnitAttachment.cs
@@ -1,9 +1,9 @@
+using Anything.Application.Common;
 using Anything.Application.Features.Inventory;
 using Anything.Core.Constants;
 using Anything.Core.Entities;
 using Anything.Core.Repositories;
 using Anything.Core.Services;
-using Anything.Core.Upload;
 using Anything.Mediator;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -28,7 +28,6 @@ public class UploadInventoryStorageUnitAttachmentHandler(
     TimeProvider timeProvider) : IRequestHandler<UploadInventoryStorageUnitAttachmentCommand, IResult>
 {
     private const string StorageUnitNotFound = "Storage unit not found.";
-    private const string InvalidFile = "No file uploaded or file is empty.";
     private const string InvalidKind = "Invalid attachment kind.";
 
     public async Task<IResult> Handle(UploadInventoryStorageUnitAttachmentCommand command, CancellationToken ct = default)
@@ -38,11 +37,8 @@ public class UploadInventoryStorageUnitAttachmentHandler(
         if (!storageUnitExists)
             return Results.NotFound(StorageUnitNotFound);
 
-        if (command.ContentLength == 0)
-            return Results.BadRequest(InvalidFile);
-
-        if (UploadLimits.ExceedsMaxFileSize(command.ContentLength))
-            return Results.BadRequest(UploadLimits.FileTooLargeMessage);
+        if (UploadValidation.ValidateFileSize(command.ContentLength) is { } sizeError)
+            return sizeError;
 
         var kind = string.IsNullOrWhiteSpace(command.Kind) ? InventoryAttachmentKinds.Other : command.Kind;
         if (!InventoryAttachmentKinds.All.Contains(kind))

--- a/src/Anything.Application/Features/Inventory/Commands/UploadInventoryStorageUnitAttachment.cs
+++ b/src/Anything.Application/Features/Inventory/Commands/UploadInventoryStorageUnitAttachment.cs
@@ -3,6 +3,7 @@ using Anything.Core.Constants;
 using Anything.Core.Entities;
 using Anything.Core.Repositories;
 using Anything.Core.Services;
+using Anything.Core.Upload;
 using Anything.Mediator;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -39,6 +40,9 @@ public class UploadInventoryStorageUnitAttachmentHandler(
 
         if (command.ContentLength == 0)
             return Results.BadRequest(InvalidFile);
+
+        if (UploadLimits.ExceedsMaxFileSize(command.ContentLength))
+            return Results.BadRequest(UploadLimits.FileTooLargeMessage);
 
         var kind = string.IsNullOrWhiteSpace(command.Kind) ? InventoryAttachmentKinds.Other : command.Kind;
         if (!InventoryAttachmentKinds.All.Contains(kind))

--- a/src/Anything.Application/Features/Notes/Commands/UploadNoteImage.cs
+++ b/src/Anything.Application/Features/Notes/Commands/UploadNoteImage.cs
@@ -1,6 +1,6 @@
+using Anything.Application.Common;
 using Anything.Contracts.Notes;
 using Anything.Core.Services;
-using Anything.Core.Upload;
 using Anything.Mediator;
 using Microsoft.AspNetCore.Http;
 
@@ -26,7 +26,6 @@ public record UploadNoteImageCommand(
 public class UploadNoteImageHandler(IImageStorageService imageStorageService)
     : IRequestHandler<UploadNoteImageCommand, IResult>
 {
-    private const string InvalidFile = "No file uploaded or file is empty.";
     private const string InvalidContentType = "Only PNG, JPEG, WebP and GIF images can be added to a note.";
     private const string StorageFolder = "notes";
 
@@ -41,11 +40,8 @@ public class UploadNoteImageHandler(IImageStorageService imageStorageService)
 
     public async Task<IResult> Handle(UploadNoteImageCommand command, CancellationToken ct = default)
     {
-        if (command.ContentLength == 0)
-            return Results.BadRequest(InvalidFile);
-
-        if (UploadLimits.ExceedsMaxFileSize(command.ContentLength))
-            return Results.BadRequest(UploadLimits.FileTooLargeMessage);
+        if (UploadValidation.ValidateFileSize(command.ContentLength) is { } sizeError)
+            return sizeError;
 
         if (!IsAllowedContentType(command.ContentType))
             return Results.BadRequest(InvalidContentType);

--- a/src/Anything.Application/Features/Notes/Commands/UploadNoteImage.cs
+++ b/src/Anything.Application/Features/Notes/Commands/UploadNoteImage.cs
@@ -1,5 +1,6 @@
 using Anything.Contracts.Notes;
 using Anything.Core.Services;
+using Anything.Core.Upload;
 using Anything.Mediator;
 using Microsoft.AspNetCore.Http;
 
@@ -42,6 +43,9 @@ public class UploadNoteImageHandler(IImageStorageService imageStorageService)
     {
         if (command.ContentLength == 0)
             return Results.BadRequest(InvalidFile);
+
+        if (UploadLimits.ExceedsMaxFileSize(command.ContentLength))
+            return Results.BadRequest(UploadLimits.FileTooLargeMessage);
 
         if (!IsAllowedContentType(command.ContentType))
             return Results.BadRequest(InvalidContentType);

--- a/src/Anything.Application/Features/Recipes/Commands/UploadRecipeImage.cs
+++ b/src/Anything.Application/Features/Recipes/Commands/UploadRecipeImage.cs
@@ -1,6 +1,7 @@
 using Anything.Core.Entities;
 using Anything.Core.Repositories;
 using Anything.Core.Services;
+using Anything.Core.Upload;
 using Anything.Mediator;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -35,6 +36,9 @@ public class UploadRecipeImageHandler(
 
         if (command.ContentLength == 0)
             return Results.BadRequest(InvalidFile);
+
+        if (UploadLimits.ExceedsMaxFileSize(command.ContentLength))
+            return Results.BadRequest(UploadLimits.FileTooLargeMessage);
 
         var storageKey = await imageStorageService.Upload(
             command.ImageStream,

--- a/src/Anything.Application/Features/Recipes/Commands/UploadRecipeImage.cs
+++ b/src/Anything.Application/Features/Recipes/Commands/UploadRecipeImage.cs
@@ -1,7 +1,7 @@
+using Anything.Application.Common;
 using Anything.Core.Entities;
 using Anything.Core.Repositories;
 using Anything.Core.Services;
-using Anything.Core.Upload;
 using Anything.Mediator;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -24,7 +24,6 @@ public class UploadRecipeImageHandler(
     IHouseholdContext householdContext) : IRequestHandler<UploadRecipeImageCommand, IResult>
 {
     private const string RecipeNotFound = "Recipe not found.";
-    private const string InvalidFile = "No file uploaded or file is empty.";
 
     public async Task<IResult> Handle(UploadRecipeImageCommand command, CancellationToken ct = default)
     {
@@ -34,11 +33,8 @@ public class UploadRecipeImageHandler(
         if (recipe is null)
             return Results.NotFound(RecipeNotFound);
 
-        if (command.ContentLength == 0)
-            return Results.BadRequest(InvalidFile);
-
-        if (UploadLimits.ExceedsMaxFileSize(command.ContentLength))
-            return Results.BadRequest(UploadLimits.FileTooLargeMessage);
+        if (UploadValidation.ValidateFileSize(command.ContentLength) is { } sizeError)
+            return sizeError;
 
         var storageKey = await imageStorageService.Upload(
             command.ImageStream,

--- a/src/Anything.Core/Upload/UploadLimits.cs
+++ b/src/Anything.Core/Upload/UploadLimits.cs
@@ -1,0 +1,28 @@
+namespace Anything.Core.Upload;
+
+/// <summary>
+/// Shared file-size limits for every upload endpoint (inventory/bill
+/// attachments, recipe images, note images), mirroring the layered-limit
+/// pattern <see cref="Anything.Core.Search.SearchDocumentLimits"/> takes for
+/// search documents.
+/// </summary>
+/// <remarks>
+/// The two limits are deliberately different sizes. Setting the transport
+/// limit (Kestrel's <c>MaxRequestBodySize</c>, nginx's
+/// <c>client_max_body_size</c>) at exactly <see cref="MaxFileSizeBytes"/>
+/// means an oversized upload never reaches a handler — Kestrel/nginx reject it
+/// first with a bodyless 413. Giving the transport layer headroom via
+/// <see cref="MaxRequestBodyBytes"/> lets the request reach the handler, which
+/// enforces <see cref="MaxFileSizeBytes"/> itself and returns a proper 400
+/// with <see cref="FileTooLargeMessage"/> instead.
+/// </remarks>
+public static class UploadLimits
+{
+    public const int MaxFileSizeBytes = 10 * 1024 * 1024;
+    public const int MaxRequestBodyBytes = 12 * 1024 * 1024;
+
+    public const string FileTooLargeMessage = "File is too large. Maximum allowed size is 10 MB.";
+
+    /// <summary>Whether an upload's declared content length exceeds <see cref="MaxFileSizeBytes"/>.</summary>
+    public static bool ExceedsMaxFileSize(long contentLength) => contentLength > MaxFileSizeBytes;
+}

--- a/src/Anything.Core/Upload/UploadLimits.cs
+++ b/src/Anything.Core/Upload/UploadLimits.cs
@@ -21,6 +21,7 @@ public static class UploadLimits
     public const int MaxFileSizeBytes = 10 * 1024 * 1024;
     public const int MaxRequestBodyBytes = 12 * 1024 * 1024;
 
+    public const string EmptyFileMessage = "No file uploaded or file is empty.";
     public const string FileTooLargeMessage = "File is too large. Maximum allowed size is 10 MB.";
 
     /// <summary>Whether an upload's declared content length exceeds <see cref="MaxFileSizeBytes"/>.</summary>

--- a/tests/Anything.Application.UnitTests/Features/Bills/BillHandlerTests.cs
+++ b/tests/Anything.Application.UnitTests/Features/Bills/BillHandlerTests.cs
@@ -6,6 +6,7 @@ using Anything.Contracts.Bills;
 using Anything.Core.Entities;
 using Anything.Core.Repositories;
 using Anything.Core.Services;
+using Anything.Core.Upload;
 using Microsoft.AspNetCore.Http.HttpResults;
 using NSubstitute;
 using Xunit;
@@ -1065,6 +1066,18 @@ public class UploadBillAttachmentHandlerTests
         _billRepo.Query().Returns(new List<Bill> { new Bill { Id = 1, Name = "Test" } }.AsAsyncQueryable());
 
         var command = new UploadBillAttachmentCommand(1, Stream.Null, "file.pdf", "application/pdf", 0);
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        Assert.IsType<BadRequest<string>>(result);
+    }
+
+    [Fact]
+    public async Task Handle_FileExceedsMaxSize_ReturnsBadRequest()
+    {
+        _billRepo.Query().Returns(new List<Bill> { new Bill { Id = 1, Name = "Test" } }.AsAsyncQueryable());
+
+        var command = new UploadBillAttachmentCommand(
+            1, Stream.Null, "file.pdf", "application/pdf", UploadLimits.MaxFileSizeBytes + 1);
         var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
 
         Assert.IsType<BadRequest<string>>(result);

--- a/tests/Anything.Application.UnitTests/Features/Notes/NoteHandlerTests.cs
+++ b/tests/Anything.Application.UnitTests/Features/Notes/NoteHandlerTests.cs
@@ -7,6 +7,7 @@ using Anything.Core.Entities;
 using Anything.Core.Repositories;
 using Anything.Core.Search;
 using Anything.Core.Services;
+using Anything.Core.Upload;
 using Microsoft.AspNetCore.Http.HttpResults;
 using NSubstitute;
 using Xunit;
@@ -252,6 +253,17 @@ public class UploadNoteImageHandlerTests
     public async Task Handle_DisallowedContentType_ReturnsBadRequest()
     {
         var command = new UploadNoteImageCommand(new MemoryStream(new byte[10]), "notes.pdf", "application/pdf", 10);
+
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        Assert.IsType<BadRequest<string>>(result);
+    }
+
+    [Fact]
+    public async Task Handle_FileExceedsMaxSize_ReturnsBadRequest()
+    {
+        var command = new UploadNoteImageCommand(
+            Stream.Null, "photo.png", "image/png", UploadLimits.MaxFileSizeBytes + 1);
 
         var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
 


### PR DESCRIPTION
Phone photos were stored at full resolution forever even though no
feature renders anything larger than 1920x1080 - inventory/bill/recipe/
note image uploads now go through a shared prepareImageForUpload (JPEG,
1920px long side, GIF/SVG passed through untouched) before the existing
byte-size check, which itself moves into one shared images.ts constant
instead of three duplicated copies. Bills gets the size check and 413
handling it never had. Two inventory toasts that swallowed the size
error message now surface it.

On the backend, all six upload handlers and Program.cs/nginx.conf now
share a single Anything.Core.Upload.UploadLimits (10 MB app limit, 12 MB
transport limit) so an oversized request reaches the handler for a
readable 400 instead of a bodyless Kestrel/nginx 413.